### PR TITLE
Add Esp Info Mock

### DIFF
--- a/src/EspClass.cpp
+++ b/src/EspClass.cpp
@@ -1,0 +1,3 @@
+#include "EspClass.h"
+
+EspClass ESP;

--- a/src/EspClass.h
+++ b/src/EspClass.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#ifndef FREE_HEAP
+#define FREE_HEAP 100000
+#endif
+
+#ifndef MAX_ALLOC_HEAP
+#define MAX_ALLOC_HEAP 80000
+#endif
+
+#ifndef FREE_PSRAM
+#define FREE_PSRAM 0  // no Pseudostatic RAM
+#endif
+
+#ifndef MOCK_CHIP_ID
+#define MOCK_CHIP_ID 0x4D4F434B  // MOCK in ascii
+#endif
+
+#ifndef FLASH_CHIP_SIZE
+#define FLASH_CHIP_SIZE (4 * 1024 * 1024)  // 4MB
+#endif
+
+#ifndef CPU_FREQ_MHZ
+#define CPU_FREQ_MHZ 240
+#endif
+
+class EspClass {
+ public:
+  size_t getFreeHeap() { return FREE_HEAP; }
+  size_t getMaxAllocHeap() { return MAX_ALLOC_HEAP; }
+  size_t getFreePsram() { return FREE_PSRAM; }
+  void restart() {}
+  uint32_t getChipId() { return MOCK_CHIP_ID; }
+  uint32_t getFlashChipSize() { return FLASH_CHIP_SIZE; }
+  uint32_t getCpuFreqMHz() { return CPU_FREQ_MHZ; }
+};
+
+extern EspClass ESP;


### PR DESCRIPTION
Add ESP system mock (_EspClass_) for native testing

## Description
Implements a mock for the global `ESP` object to support native testing. This allows code querying system telemetry or memory status to compile and run on host machines.

## Key Features
* **Drop-in Compatibility:** Named `EspClass` to match the official ESP32 Arduino Core to ensure reference-passing and type-checks work.
* **Configurable:** Uses `#ifndef` guards for all return values (Heap, PSRAM, ChipID), allowing hardware profiles to be injected via compiler flags.
 * **restart():** Implemented as a no-op to satisfy the linker without terminating the test process.

## Question

- Shouldn't **restart()** give some feedback? Something like a terminal output to make the tester aware of the event.

Closes #15 