### PR TITLE
Task Watchdog Timer

### DIFF
--- a/src/esp_task_wtd.h
+++ b/src/esp_task_wtd.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+
+typedef int esp_err_t;
+#define ESP_OK 0
+
+inline esp_err_t esp_task_wdt_add(TaskHandle_t) { return ESP_OK; }
+inline esp_err_t esp_task_wdt_reset(void) { return ESP_OK; }
+inline esp_err_t esp_task_wdt_delete(TaskHandle_t) { return ESP_OK; }
+inline esp_err_t esp_task_wdt_init(uint32_t, bool) { return ESP_OK; }
+inline esp_err_t esp_task_wdt_deinit(void) { return ESP_OK; }


### PR DESCRIPTION
## Description
Implements a mock for the ESP-IDF Task Watchdog Timer (TWDT) API. This allows native tests to compile and run code that manages watchdog registration and resets without requiring the ESP-IDF hardware abstraction layer.

## Key Changes
* **API Coverage:** Implements the core `esp_task_wdt` functions (`add`, `reset`, `delete`, `init`, `deinit`).
* **Header Compatibility:** Includes `freertos/FreeRTOS.h` to support the `TaskHandle_t` type, matching the original ESP-IDF function signatures.
* **Return Values:** All functions return `ESP_OK` (0) by default to simulate successful watchdog management.
* **No-op Implementation:** Uses `inline` functions to satisfy the linker and minimize overhead during test execution.

## Use Case
Prevents compilation and linker errors in firmware that uses watchdog timers to monitor long-running tasks or state machines.

Closes #17 