### PR TITLE
Heap Functions

### DIFF
--- a/src/esp_heap.h
+++ b/src/esp_heap.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+#define MALLOC_CAP_SPIRAM (1 << 10)
+#define MALLOC_CAP_8BIT (1 << 2)
+#define MALLOC_CAP_32BIT (1 << 1)
+#define MALLOC_CAP_DEFAULT (1 << 3)
+
+inline void* ps_malloc(size_t size) { return malloc(size); }
+inline void* heap_caps_malloc(size_t size, uint32_t) { return malloc(size); }
+inline void* heap_caps_calloc(size_t n, size_t size, uint32_t) { return calloc(n, size); }
+inline void* heap_caps_realloc(void* ptr, size_t size, uint32_t) { return realloc(ptr, size); }
+inline void heap_caps_free(void* ptr) { free(ptr); }
+inline size_t heap_caps_get_free_size(uint32_t) { return 100000; }
+inline bool psramFound(void) { return false; }


### PR DESCRIPTION
## Description
Implements mocks for ESP32 heap capability functions and PSRAM allocation. This allows firmware that explicitly manages memory types (e.g., SPIRAM, 8-bit, 32-bit) to compile and execute natively by bridging these calls to standard C memory management.

## Key Changes
* **Standard Mapping:** mocks `ps_malloc` and `heap_caps_*` functions directly to `malloc`, `calloc`, `realloc`, and `free`.
* **Capability Macros:** Includes standard ESP capability flags (`MALLOC_CAP_SPIRAM`, `MALLOC_CAP_8BIT`, etc.) to satisfy compiler requirements in hardware-specific logic.
* **PSRAM Detection:** `psramFound()` returns `false` by default to ensure native tests follow the standard internal RAM code paths, preventing attempts to access hardware-specific SPIRAM features.

Closes #18 