### PR TITLE
fix: exclude StreamGMock from PlatformIO default build

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,9 @@
+{
+  "name": "ArduinoMock",
+  "version": "0.2.0-rc.1",
+  "description": "Arduino native mocks for host-based testing",
+  "platforms": ["native"],
+  "build": {
+    "srcFilter": ["+<*>", "-<stream/StreamGMock.cpp>"]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `library.json` with a `srcFilter` that excludes `stream/StreamGMock.cpp` from the default PlatformIO build
- Mirrors the existing CMake behavior where `ARDUINOMOCK_USE_GMOCK` is OFF by default
- Fixes PlatformIO users hitting `gmock/gmock.h` not found errors when using ArduinoMock as a `lib_deps` dependency

Closes #38

## Test plan
- [x] Run `pio test -e native` with ArduinoMock as a `lib_deps` dependency — build should succeed without gmock

🤖 Generated with [Claude Code](https://claude.com/claude-code)