### PR TITLE
feat: Add FreeRTOS software timer mock (timers.h)

### DIFF
--- a/src/freertos/FreeRTOS.h
+++ b/src/freertos/FreeRTOS.h
@@ -5,6 +5,7 @@
 #include "queue/queue.h"
 #include "semaphore/semaphore.h"
 #include "task/task.h"
+#include "timer/timer.h"
 
 inline BaseType_t xTaskCreatePinnedToCore(
     TaskFunction_t pxTaskCode, const char* const pcName, const portSTACK_TYPE usStackDepth,

--- a/src/freertos/timer/timer.cpp
+++ b/src/freertos/timer/timer.cpp
@@ -1,0 +1,91 @@
+#include "timer.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+struct MockTimer {
+  std::string name;
+  uint32_t period;
+  bool autoReload;
+  bool active;
+  void* timerID;
+  TimerCallbackFunction_t callback;
+};
+
+static std::vector<MockTimer*> timers;
+
+TimerHandle_t xTimerCreate(
+    const char* name, uint32_t periodTicks, BaseType_t autoReload, void* timerID,
+    TimerCallbackFunction_t callback) {
+  MockTimer* t = new MockTimer();
+  t->name = name ? name : "";
+  t->period = periodTicks;
+  t->autoReload = (autoReload != 0);
+  t->active = false;
+  t->timerID = timerID;
+  t->callback = callback;
+  timers.push_back(t);
+  return static_cast<TimerHandle_t>(t);
+}
+
+BaseType_t xTimerStart(TimerHandle_t timer, TickType_t) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  t->active = true;
+  return pdPASS;
+}
+
+BaseType_t xTimerStop(TimerHandle_t timer, TickType_t) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  t->active = false;
+  return pdPASS;
+}
+
+BaseType_t xTimerReset(TimerHandle_t timer, TickType_t) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  t->active = true;
+  return pdPASS;
+}
+
+BaseType_t xTimerDelete(TimerHandle_t timer, TickType_t) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  timers.erase(std::remove(timers.begin(), timers.end(), t), timers.end());
+  delete t;
+  return pdPASS;
+}
+
+BaseType_t xTimerChangePeriod(TimerHandle_t timer, uint32_t newPeriod, TickType_t) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  t->period = newPeriod;
+  return pdPASS;
+}
+
+void* pvTimerGetTimerID(TimerHandle_t timer) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  return t->timerID;
+}
+
+const char* pcTimerGetName(TimerHandle_t timer) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  return t->name.c_str();
+}
+
+void mockProcessTimers() {
+  for (size_t i = 0; i < timers.size(); i++) {
+    if (timers[i]->active && timers[i]->callback) {
+      timers[i]->callback(static_cast<TimerHandle_t>(timers[i]));
+    }
+  }
+}
+
+void mockFireTimer(TimerHandle_t timer) {
+  MockTimer* t = static_cast<MockTimer*>(timer);
+  if (t->callback) { t->callback(timer); }
+}
+
+size_t mockGetTimerCount() { return timers.size(); }
+
+void mockClearTimers() {
+  for (size_t i = 0; i < timers.size(); i++) { delete timers[i]; }
+  timers.clear();
+}

--- a/src/freertos/timer/timer.h
+++ b/src/freertos/timer/timer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "freertos/projdefs.h"
+
+typedef void* TimerHandle_t;
+typedef void (*TimerCallbackFunction_t)(TimerHandle_t);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TimerHandle_t xTimerCreate(
+    const char* name, uint32_t periodTicks, BaseType_t autoReload, void* timerID,
+    TimerCallbackFunction_t callback);
+
+BaseType_t xTimerStart(TimerHandle_t timer, TickType_t ticksToWait);
+BaseType_t xTimerStop(TimerHandle_t timer, TickType_t ticksToWait);
+BaseType_t xTimerReset(TimerHandle_t timer, TickType_t ticksToWait);
+BaseType_t xTimerDelete(TimerHandle_t timer, TickType_t ticksToWait);
+BaseType_t xTimerChangePeriod(TimerHandle_t timer, uint32_t newPeriod, TickType_t ticksToWait);
+void* pvTimerGetTimerID(TimerHandle_t timer);
+const char* pcTimerGetName(TimerHandle_t timer);
+
+// Test helpers
+void mockProcessTimers();
+void mockFireTimer(TimerHandle_t timer);
+size_t mockGetTimerCount();
+void mockClearTimers();
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/timer_gtest.cpp
+++ b/test/timer_gtest.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include "freertos/FreeRTOS.h"
+
+static int callbackCount = 0;
+static TimerHandle_t lastCallbackTimer = nullptr;
+
+static void testCallback(TimerHandle_t timer) {
+  callbackCount++;
+  lastCallbackTimer = timer;
+}
+
+class TimerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mockClearTimers();
+    callbackCount = 0;
+    lastCallbackTimer = nullptr;
+  }
+  void TearDown() override { mockClearTimers(); }
+};
+
+TEST_F(TimerTest, CreateReturnsNonNull) {
+  TimerHandle_t t = xTimerCreate("test", 1000, pdFALSE, nullptr, testCallback);
+  ASSERT_NE(t, nullptr);
+}
+
+TEST_F(TimerTest, GetNameReturnsCorrectName) {
+  TimerHandle_t t = xTimerCreate("myTimer", 1000, pdFALSE, nullptr, testCallback);
+  EXPECT_STREQ(pcTimerGetName(t), "myTimer");
+}
+
+TEST_F(TimerTest, GetTimerIDReturnsCorrectID) {
+  int id = 42;
+  TimerHandle_t t = xTimerCreate("test", 1000, pdFALSE, &id, testCallback);
+  EXPECT_EQ(pvTimerGetTimerID(t), &id);
+}
+
+TEST_F(TimerTest, StartAndProcessFiresCallback) {
+  TimerHandle_t t = xTimerCreate("test", 1000, pdFALSE, nullptr, testCallback);
+  EXPECT_EQ(xTimerStart(t, 0), pdPASS);
+  mockProcessTimers();
+  EXPECT_EQ(callbackCount, 1);
+  EXPECT_EQ(lastCallbackTimer, t);
+}
+
+TEST_F(TimerTest, StoppedTimerDoesNotFire) {
+  TimerHandle_t t = xTimerCreate("test", 1000, pdFALSE, nullptr, testCallback);
+  xTimerStart(t, 0);
+  xTimerStop(t, 0);
+  mockProcessTimers();
+  EXPECT_EQ(callbackCount, 0);
+}
+
+TEST_F(TimerTest, MockFireTimerFiresSpecificTimer) {
+  TimerHandle_t t1 = xTimerCreate("t1", 1000, pdFALSE, nullptr, testCallback);
+  TimerHandle_t t2 = xTimerCreate("t2", 2000, pdFALSE, nullptr, testCallback);
+  (void)t1;
+  mockFireTimer(t2);
+  EXPECT_EQ(callbackCount, 1);
+  EXPECT_EQ(lastCallbackTimer, t2);
+}
+
+TEST_F(TimerTest, ChangePeriodUpdatesPeriod) {
+  TimerHandle_t t = xTimerCreate("test", 1000, pdFALSE, nullptr, testCallback);
+  EXPECT_EQ(xTimerChangePeriod(t, 5000, 0), pdPASS);
+}
+
+TEST_F(TimerTest, DeleteRemovesTimer) {
+  TimerHandle_t t1 = xTimerCreate("t1", 1000, pdFALSE, nullptr, testCallback);
+  xTimerCreate("t2", 2000, pdFALSE, nullptr, testCallback);
+  EXPECT_EQ(mockGetTimerCount(), 2u);
+  xTimerDelete(t1, 0);
+  EXPECT_EQ(mockGetTimerCount(), 1u);
+}
+
+TEST_F(TimerTest, GetTimerCountTracksTimers) {
+  EXPECT_EQ(mockGetTimerCount(), 0u);
+  xTimerCreate("t1", 100, pdFALSE, nullptr, testCallback);
+  EXPECT_EQ(mockGetTimerCount(), 1u);
+  xTimerCreate("t2", 200, pdFALSE, nullptr, testCallback);
+  EXPECT_EQ(mockGetTimerCount(), 2u);
+}
+
+TEST_F(TimerTest, ClearTimersRemovesAll) {
+  xTimerCreate("t1", 100, pdFALSE, nullptr, testCallback);
+  xTimerCreate("t2", 200, pdFALSE, nullptr, testCallback);
+  mockClearTimers();
+  EXPECT_EQ(mockGetTimerCount(), 0u);
+}
+
+TEST_F(TimerTest, OnlyActiveTimersFire) {
+  TimerHandle_t t1 = xTimerCreate("active", 100, pdFALSE, nullptr, testCallback);
+  xTimerCreate("inactive", 200, pdFALSE, nullptr, testCallback);
+  xTimerStart(t1, 0);
+  mockProcessTimers();
+  EXPECT_EQ(callbackCount, 1);
+  EXPECT_EQ(lastCallbackTimer, t1);
+}
+
+TEST_F(TimerTest, ResetReactivatesStoppedTimer) {
+  TimerHandle_t t = xTimerCreate("test", 1000, pdFALSE, nullptr, testCallback);
+  xTimerStart(t, 0);
+  xTimerStop(t, 0);
+  mockProcessTimers();
+  EXPECT_EQ(callbackCount, 0);
+
+  xTimerReset(t, 0);
+  mockProcessTimers();
+  EXPECT_EQ(callbackCount, 1);
+}


### PR DESCRIPTION
## Summary
- Adds `src/freertos/timer/timer.h` + `timer.cpp` with full FreeRTOS timer API mock
- Supports `xTimerCreate`, `xTimerStart/Stop/Reset/Delete`, `xTimerChangePeriod`, `pvTimerGetTimerID`, `pcTimerGetName`
- Test helpers: `mockProcessTimers()`, `mockFireTimer()`, `mockGetTimerCount()`, `mockClearTimers()`
- 12 comprehensive GTest tests

Closes #43

## Test plan
- [x] All existing tests pass
- [x] New `timer_gtest` suite passes (12 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)