### PR TITLE
feat: Add HardwareSerial.h with buffered I/O and test helpers

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -12,6 +12,7 @@ typedef bool boolean;
 typedef uint8_t byte;
 typedef uint16_t word;
 
+#include "HardwareSerial.h"
 #include "Stream.h"
 #include "WString.h"
 #include "times.h"

--- a/src/HardwareSerial.cpp
+++ b/src/HardwareSerial.cpp
@@ -1,4 +1,4 @@
-#include "Stream.h"
+#include "HardwareSerial.h"
 
 HardwareSerial Serial(0);
 HardwareSerial Serial2(1);

--- a/src/HardwareSerial.h
+++ b/src/HardwareSerial.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <queue>
+#include <string>
+
+#include "Stream.h"
+
+// ESP32 serial config constants
+#ifndef SERIAL_8N1
+#define SERIAL_8N1 0x800001cUL
+#endif
+#ifndef SERIAL_8N2
+#define SERIAL_8N2 0x800003cUL
+#endif
+#ifndef SERIAL_8E1
+#define SERIAL_8E1 0x8000016UL
+#endif
+#ifndef SERIAL_8O1
+#define SERIAL_8O1 0x8000017UL
+#endif
+
+class HardwareSerial : public Stream {
+ public:
+  explicit HardwareSerial(int port) : _port(port) {}
+
+  // --- Arduino / ESP32 API ---
+
+  void begin(unsigned long baud) { _baud = baud; }
+
+  void begin(unsigned long baud, uint32_t config) {
+    _baud = baud;
+    _config = config;
+  }
+
+  void begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin) {
+    _baud = baud;
+    _config = config;
+    _rxPin = rxPin;
+    _txPin = txPin;
+  }
+
+  void end() { reset(); }
+
+  unsigned long baudRate() const { return _baud; }
+
+  // --- Stream interface ---
+
+  int available() override {
+    std::lock_guard<std::mutex> lock(_rxMu);
+    return static_cast<int>(_rxBuf.size());
+  }
+
+  int read() override {
+    std::lock_guard<std::mutex> lock(_rxMu);
+    if (_rxBuf.empty()) return -1;
+    int c = _rxBuf.front();
+    _rxBuf.pop();
+    return c;
+  }
+
+  int peek() override {
+    std::lock_guard<std::mutex> lock(_rxMu);
+    if (_rxBuf.empty()) return -1;
+    return _rxBuf.front();
+  }
+
+  size_t write(uint8_t c) override {
+    std::lock_guard<std::mutex> lock(_txMu);
+    _txBuf.push(c);
+    return 1;
+  }
+
+  size_t write(const uint8_t* buffer, size_t size) override {
+    std::lock_guard<std::mutex> lock(_txMu);
+    for (size_t i = 0; i < size; i++) _txBuf.push(buffer[i]);
+    return size;
+  }
+
+  void flush() override {
+    std::lock_guard<std::mutex> lock(_txMu);
+    while (!_txBuf.empty()) _txBuf.pop();
+  }
+
+  // --- Test helpers ---
+
+  void injectRxData(const std::string& data) {
+    std::lock_guard<std::mutex> lock(_rxMu);
+    for (unsigned char c : data) _rxBuf.push(c);
+  }
+
+  std::string getTxData() {
+    std::lock_guard<std::mutex> lock(_txMu);
+    std::string result;
+    while (!_txBuf.empty()) {
+      result += static_cast<char>(_txBuf.front());
+      _txBuf.pop();
+    }
+    return result;
+  }
+
+  void clearBuffers() {
+    std::lock_guard<std::mutex> rxLock(_rxMu);
+    std::lock_guard<std::mutex> txLock(_txMu);
+    std::queue<uint8_t>().swap(_rxBuf);
+    std::queue<uint8_t>().swap(_txBuf);
+  }
+
+  void reset() {
+    clearBuffers();
+    _baud = 0;
+    _config = SERIAL_8N1;
+    _rxPin = -1;
+    _txPin = -1;
+  }
+
+ private:
+  int _port;
+  unsigned long _baud = 0;
+  uint32_t _config = SERIAL_8N1;
+  int8_t _rxPin = -1;
+  int8_t _txPin = -1;
+
+  std::queue<uint8_t> _rxBuf;
+  std::queue<uint8_t> _txBuf;
+  std::mutex _rxMu;
+  std::mutex _txMu;
+};
+
+extern HardwareSerial Serial;
+extern HardwareSerial Serial2;
+extern HardwareSerial Serial3;

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -47,4 +47,3 @@ class Stream {
     return n;
   }
 };
-

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -48,36 +48,3 @@ class Stream {
   }
 };
 
-// ESP32 serial config constants
-#ifndef SERIAL_8N1
-#define SERIAL_8N1 0x800001cUL
-#endif
-#ifndef SERIAL_8N2
-#define SERIAL_8N2 0x800003cUL
-#endif
-#ifndef SERIAL_8E1
-#define SERIAL_8E1 0x8000016UL
-#endif
-#ifndef SERIAL_8O1
-#define SERIAL_8O1 0x8000017UL
-#endif
-
-class HardwareSerial : public Stream {
- public:
-  HardwareSerial(int indexA) {}
-  void begin(unsigned long baud) {}
-  void begin(unsigned long baud, uint32_t config) {}
-  void begin(unsigned long baud, uint32_t config, int8_t rxPin, int8_t txPin) {}
-  void println(const String& str) {}
-  void print(const String& str) {}
-  size_t write(uint8_t c) { return 1; }
-  size_t write(const uint8_t* buffer, size_t size) { return size; }
-  void flush() {}
-  int available() { return 0; }
-  int read() { return -1; }
-  int peek() { return -1; }
-};
-
-extern HardwareSerial Serial;
-extern HardwareSerial Serial2;
-extern HardwareSerial Serial3;

--- a/test/hardware_serial_gtest.cpp
+++ b/test/hardware_serial_gtest.cpp
@@ -1,26 +1,160 @@
 #include <gtest/gtest.h>
 
-#include "Stream.h"
+#include "HardwareSerial.h"
+
+// --- begin() overloads ---
 
 TEST(HardwareSerialTest, BeginBaudOnly) {
   HardwareSerial s(0);
-  s.begin(115200);  // should compile and not crash
+  s.begin(115200);
+  EXPECT_EQ(s.baudRate(), 115200UL);
 }
 
 TEST(HardwareSerialTest, BeginBaudWithConfig) {
   HardwareSerial s(0);
-  s.begin(115200, SERIAL_8N1);
+  s.begin(9600, SERIAL_8N1);
+  EXPECT_EQ(s.baudRate(), 9600UL);
 }
 
 TEST(HardwareSerialTest, BeginBaudConfigPins) {
   HardwareSerial s(1);
-  s.begin(9600, SERIAL_8N1, 16, 17);
+  s.begin(115200, SERIAL_8N1, 16, 17);
+  EXPECT_EQ(s.baudRate(), 115200UL);
 }
 
-TEST(HardwareSerialTest, SerialConfigConstantsDefined) { EXPECT_EQ(SERIAL_8N1, 0x800001cUL); }
+// --- Serial config constants ---
+
+TEST(HardwareSerialTest, ConfigConstantsDefined) {
+  EXPECT_EQ(SERIAL_8N1, 0x800001cUL);
+  EXPECT_EQ(SERIAL_8N2, 0x800003cUL);
+  EXPECT_EQ(SERIAL_8E1, 0x8000016UL);
+  EXPECT_EQ(SERIAL_8O1, 0x8000017UL);
+}
+
+// --- write / getTxData ---
+
+TEST(HardwareSerialTest, WriteSingleByte) {
+  HardwareSerial s(0);
+  EXPECT_EQ(s.write(static_cast<uint8_t>('A')), 1u);
+  EXPECT_EQ(s.getTxData(), "A");
+}
+
+TEST(HardwareSerialTest, WriteBuffer) {
+  HardwareSerial s(0);
+  const uint8_t buf[] = {'h', 'i', '\n'};
+  EXPECT_EQ(s.write(buf, 3), 3u);
+  EXPECT_EQ(s.getTxData(), "hi\n");
+}
+
+TEST(HardwareSerialTest, GetTxDataDrainsBuffer) {
+  HardwareSerial s(0);
+  s.write(static_cast<uint8_t>('X'));
+  s.getTxData();
+  EXPECT_EQ(s.getTxData(), "");
+}
+
+// --- injectRxData / read / available / peek ---
+
+TEST(HardwareSerialTest, AvailableReflectsInjectedBytes) {
+  HardwareSerial s(0);
+  EXPECT_EQ(s.available(), 0);
+  s.injectRxData("abc");
+  EXPECT_EQ(s.available(), 3);
+}
+
+TEST(HardwareSerialTest, ReadConsumesBytes) {
+  HardwareSerial s(0);
+  s.injectRxData("hi");
+  EXPECT_EQ(s.read(), 'h');
+  EXPECT_EQ(s.read(), 'i');
+  EXPECT_EQ(s.read(), -1);
+}
+
+TEST(HardwareSerialTest, PeekDoesNotConsume) {
+  HardwareSerial s(0);
+  s.injectRxData("Z");
+  EXPECT_EQ(s.peek(), 'Z');
+  EXPECT_EQ(s.peek(), 'Z');
+  EXPECT_EQ(s.available(), 1);
+}
+
+TEST(HardwareSerialTest, ReadEmptyReturnsMinusOne) {
+  HardwareSerial s(0);
+  EXPECT_EQ(s.read(), -1);
+}
+
+TEST(HardwareSerialTest, PeekEmptyReturnsMinusOne) {
+  HardwareSerial s(0);
+  EXPECT_EQ(s.peek(), -1);
+}
+
+// --- flush ---
+
+TEST(HardwareSerialTest, FlushClearsTxBuffer) {
+  HardwareSerial s(0);
+  s.write(static_cast<uint8_t>('X'));
+  s.flush();
+  EXPECT_EQ(s.getTxData(), "");
+}
+
+// --- clearBuffers ---
+
+TEST(HardwareSerialTest, ClearBuffersEmptiesBoth) {
+  HardwareSerial s(0);
+  s.injectRxData("data");
+  s.write(static_cast<uint8_t>('X'));
+  s.clearBuffers();
+  EXPECT_EQ(s.available(), 0);
+  EXPECT_EQ(s.getTxData(), "");
+}
+
+// --- reset ---
+
+TEST(HardwareSerialTest, ResetClearsStateAndBuffers) {
+  HardwareSerial s(0);
+  s.begin(115200, SERIAL_8N1, 4, 5);
+  s.injectRxData("hello");
+  s.write(static_cast<uint8_t>('!'));
+  s.reset();
+  EXPECT_EQ(s.baudRate(), 0UL);
+  EXPECT_EQ(s.available(), 0);
+  EXPECT_EQ(s.getTxData(), "");
+}
+
+// --- end ---
+
+TEST(HardwareSerialTest, EndResetsState) {
+  HardwareSerial s(0);
+  s.begin(9600);
+  s.injectRxData("x");
+  s.end();
+  EXPECT_EQ(s.baudRate(), 0UL);
+  EXPECT_EQ(s.available(), 0);
+}
+
+// --- multi-instance independence ---
+
+TEST(HardwareSerialTest, InstancesAreIndependent) {
+  HardwareSerial s0(0);
+  HardwareSerial s1(1);
+  s0.injectRxData("from-s0");
+  s1.injectRxData("from-s1");
+  EXPECT_EQ(s0.available(), 7);
+  EXPECT_EQ(s1.available(), 7);
+  s0.read();
+  EXPECT_EQ(s1.available(), 7);
+}
+
+// --- global instances ---
 
 TEST(HardwareSerialTest, GlobalSerialInstances) {
   Serial.begin(115200);
   Serial2.begin(9600, SERIAL_8N1, 16, 17);
   Serial3.begin(115200, SERIAL_8N1);
+  EXPECT_EQ(Serial.baudRate(), 115200UL);
+  EXPECT_EQ(Serial2.baudRate(), 9600UL);
+  EXPECT_EQ(Serial3.baudRate(), 115200UL);
+  Serial.reset();
+  Serial2.reset();
+  Serial3.reset();
 }


### PR DESCRIPTION
## Summary

- **New `src/HardwareSerial.h`** — proper buffer-backed implementation replacing the inline stub that lived in `Stream.h`
  - Thread-safe RX/TX queues (`std::queue<uint8_t>` + `std::mutex`) matching the `MockStream` pattern
  - Full `Stream` interface: `read()`, `write()`, `available()`, `peek()`, `flush()`
  - Stores `begin()` config: baud rate, serial format (`SERIAL_8N1` etc.), RX/TX pins
  - Test helpers: `injectRxData()`, `getTxData()`, `clearBuffers()`, `reset()`, `end()`
  - `baudRate()` accessor for asserting config in tests
- **`src/Stream.h`** — stub `HardwareSerial` class and `SERIAL_*` constants removed (moved to `HardwareSerial.h`)
- **`src/HardwareSerial.cpp`** — updated include to `HardwareSerial.h`
- **`src/Arduino.h`** — added `#include "HardwareSerial.h"` so it remains the single entry point
- **`test/hardware_serial_gtest.cpp`** — expanded from 5 smoke tests to 18 behavioural tests covering write/read round-trip, peek, flush, clearBuffers, reset, end, multi-instance independence, and global instances

## Test plan

- [x] 13/13 tests pass (`ctest`)
- [x] `hardware_serial_gtest`: 18 tests, all green
- [x] No regressions in existing suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)