### PR TITLE
feat: Add getEfuseMac() to EspClass and DEC/HEX/OCT/BIN constants (#56)

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -12,6 +12,11 @@ typedef bool boolean;
 typedef uint8_t byte;
 typedef uint16_t word;
 
+#define DEC 10
+#define HEX 16
+#define OCT 8
+#define BIN 2
+
 #include "HardwareSerial.h"
 #include "Stream.h"
 #include "WString.h"

--- a/src/EspClass.h
+++ b/src/EspClass.h
@@ -35,6 +35,10 @@
 #define RTC_DATA_ATTR
 #endif
 
+#ifndef MOCK_EFUSE_MAC
+#define MOCK_EFUSE_MAC 0x112233445566ULL
+#endif
+
 class EspClass {
  public:
   size_t getFreeHeap() { return FREE_HEAP; }
@@ -45,6 +49,7 @@ class EspClass {
   uint32_t getFlashChipSize() { return FLASH_CHIP_SIZE; }
   uint32_t getFlashChipSpeed() { return FLASH_CHIP_SPEED; }
   uint32_t getCpuFreqMHz() { return CPU_FREQ_MHZ; }
+  uint64_t getEfuseMac() { return MOCK_EFUSE_MAC; }
 };
 
 extern EspClass ESP;

--- a/src/WString.h
+++ b/src/WString.h
@@ -1,7 +1,21 @@
 #pragma once
 
+#include <cstdio>
 #include <string>
 #include <type_traits>
+
+#ifndef DEC
+#define DEC 10
+#endif
+#ifndef HEX
+#define HEX 16
+#endif
+#ifndef OCT
+#define OCT 8
+#endif
+#ifndef BIN
+#define BIN 2
+#endif
 
 class String {
  private:
@@ -16,6 +30,32 @@ class String {
 
   template <typename T, typename = typename std::enable_if<std::is_integral<T>::value>::type>
   explicit String(T value) : _data(std::to_string(value)) {}
+
+  String(unsigned long value, unsigned char base) {
+    if (base == HEX) {
+      char buf[17];
+      snprintf(buf, sizeof(buf), "%lx", value);
+      _data = buf;
+    } else if (base == OCT) {
+      char buf[23];
+      snprintf(buf, sizeof(buf), "%lo", value);
+      _data = buf;
+    } else if (base == BIN) {
+      if (value == 0) {
+        _data = "0";
+        return;
+      }
+      std::string bits;
+      unsigned long v = value;
+      while (v > 0) {
+        bits = static_cast<char>('0' + (v & 1)) + bits;
+        v >>= 1;
+      }
+      _data = bits;
+    } else {
+      _data = std::to_string(value);
+    }
+  }
 
   String& operator=(const char* str) {
     _data = str;

--- a/test/esp32_apis_gtest.cpp
+++ b/test/esp32_apis_gtest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "Arduino.h"
 #include "EspClass.h"
 #include "WiFi.h"
 #include "WiFiClient.h"
@@ -65,3 +66,17 @@ TEST(EspClassTest, RtcDataAttrDefined) {
   RTC_DATA_ATTR int x = 42;
   EXPECT_EQ(x, 42);
 }
+
+TEST(EspClassTest, GetEfuseMacReturnsMockValue) {
+  EXPECT_EQ(ESP.getEfuseMac(), static_cast<uint64_t>(MOCK_EFUSE_MAC));
+}
+
+// --- String base constructors ---
+
+TEST(StringBaseTest, HexFormatting) { EXPECT_EQ(String(0xABCDUL, HEX), "abcd"); }
+
+TEST(StringBaseTest, BinaryFormatting) { EXPECT_EQ(String(255UL, BIN), "11111111"); }
+
+TEST(StringBaseTest, OctalFormatting) { EXPECT_EQ(String(8UL, OCT), "10"); }
+
+TEST(StringBaseTest, DecimalFormatting) { EXPECT_EQ(String(42UL, DEC), "42"); }


### PR DESCRIPTION
## Summary

Fixes #56

- Add `getEfuseMac()` to `EspClass` returning `MOCK_EFUSE_MAC` (`0x112233445566ULL`, overridable via `#define`)
- Add `DEC/HEX/OCT/BIN` numeric base constants to `Arduino.h` and `WString.h`
- Add `String(unsigned long, unsigned char base)` constructor supporting hex, octal, binary, and decimal formatting

## Test plan
- [x] `ESP.getEfuseMac()` returns `MOCK_EFUSE_MAC`
- [x] `String(0xABCDUL, HEX)` == `"abcd"`
- [x] `String(255UL, BIN)` == `"11111111"`
- [x] `String(8UL, OCT)` == `"10"`
- [x] All 13 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)