### PR TITLE
fix: Define ARDUINO macro in Arduino.h

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -7,6 +7,10 @@
 #include <random>
 #include <thread>
 
+#ifndef ARDUINO
+#define ARDUINO 10813
+#endif
+
 // Arduino type definitions
 typedef bool boolean;
 typedef uint8_t byte;


### PR DESCRIPTION
## Summary

Fixes #63

Adds `#ifndef ARDUINO / #define ARDUINO 10813 / #endif` to `Arduino.h`, matching how the real Arduino framework works — including `Arduino.h` guarantees the macro is defined. This unblocks libraries like TinyGPSPlus that guard Arduino-specific code with `#if !defined(ARDUINO)`.

The `#ifndef` guard ensures consumer build systems that already pass `-DARDUINO=...` are not overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)