### PR TITLE
fix: Add wifi_mode_t enum and WiFiClass::mode()

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -114,6 +114,7 @@ void WiFiClass::onEvent(std::function<void(int)>) {}
 void WiFiClass::reset() {
   _rssi = -50;
   _status = WL_CONNECTED;
+  _mode = WIFI_STA;
   _scanResults.clear();
   _dnsSuccess = true;
   _beginConnects = true;

--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -8,6 +8,14 @@
 
 #include "IPAddress.h"
 
+// WiFi mode — matches ESP32 Arduino Core wifi_mode_t values
+typedef enum {
+  WIFI_OFF = 0,
+  WIFI_STA = 1,
+  WIFI_AP = 2,
+  WIFI_AP_STA = 3,
+} wifi_mode_t;
+
 // Values match ESP32 Arduino Core wifi_sta_status_t
 typedef enum {
   WL_IDLE_STATUS = 0,
@@ -34,6 +42,8 @@ class WiFiClass {
   IPAddress localIP();
   String macAddress();
   bool begin(const char* ssid, const char* password);
+  void mode(wifi_mode_t m) { _mode = m; }
+  wifi_mode_t getMode() const { return _mode; }
   void disconnect();
 
   // Extended API
@@ -62,6 +72,7 @@ class WiFiClass {
  private:
   int32_t _rssi = -50;
   wl_status_t _status = WL_CONNECTED;
+  wifi_mode_t _mode = WIFI_STA;
   std::vector<MockScanResult> _scanResults;
   bool _dnsSuccess = true;
   bool _beginConnects = true;

--- a/test/wifi_gtest.cpp
+++ b/test/wifi_gtest.cpp
@@ -108,6 +108,40 @@ TEST_F(WiFiTest, ResetRestoresDefaults) {
   EXPECT_EQ(WiFi.scanNetworks(), 0);
 }
 
+// --- wifi_mode_t constants ---
+
+TEST_F(WiFiTest, WifiModeConstantsMatchESP32Values) {
+  EXPECT_EQ(WIFI_OFF, 0);
+  EXPECT_EQ(WIFI_STA, 1);
+  EXPECT_EQ(WIFI_AP, 2);
+  EXPECT_EQ(WIFI_AP_STA, 3);
+}
+
+// --- mode() / getMode() ---
+
+TEST_F(WiFiTest, DefaultModeIsWifiSta) { EXPECT_EQ(WiFi.getMode(), WIFI_STA); }
+
+TEST_F(WiFiTest, ModeStoresValue) {
+  WiFi.mode(WIFI_AP);
+  EXPECT_EQ(WiFi.getMode(), WIFI_AP);
+}
+
+TEST_F(WiFiTest, ModeApSta) {
+  WiFi.mode(WIFI_AP_STA);
+  EXPECT_EQ(WiFi.getMode(), WIFI_AP_STA);
+}
+
+TEST_F(WiFiTest, ModeOff) {
+  WiFi.mode(WIFI_OFF);
+  EXPECT_EQ(WiFi.getMode(), WIFI_OFF);
+}
+
+TEST_F(WiFiTest, ResetRestoresDefaultMode) {
+  WiFi.mode(WIFI_AP);
+  WiFi.reset();
+  EXPECT_EQ(WiFi.getMode(), WIFI_STA);
+}
+
 // WiFiClient tests
 
 TEST(WiFiClientTest, ConnectsByDefault) {


### PR DESCRIPTION
## Summary

Fixes #67

- Adds `wifi_mode_t` enum (`WIFI_OFF=0`, `WIFI_STA=1`, `WIFI_AP=2`, `WIFI_AP_STA=3`) matching ESP32 Arduino Core values
- Adds `WiFi.mode(wifi_mode_t)` stub and `WiFi.getMode()` accessor
- `WiFi.reset()` restores default `WIFI_STA`
- 5 new tests in `wifi_gtest.cpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)