### PR TITLE
fix: Add File::readStringUntil() and FS.h to LittleFS/SPIFFS mock

### DIFF
--- a/src/FS.h
+++ b/src/FS.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "SPIFFS.h"

--- a/src/SPIFFS.cpp
+++ b/src/SPIFFS.cpp
@@ -14,6 +14,17 @@ String File::readString() {
   return String(_contentPtr->c_str());
 }
 
+String File::readStringUntil(char terminator) {
+  if (!_contentPtr) return String("");
+  std::string result;
+  while (_readPos < _contentPtr->size()) {
+    char c = (*_contentPtr)[_readPos++];
+    if (c == terminator) break;
+    result += c;
+  }
+  return String(result.c_str());
+}
+
 size_t File::write(uint8_t c) {
   if (!_contentPtr) return 0;
   _contentPtr->push_back(static_cast<char>(c));

--- a/src/SPIFFS.h
+++ b/src/SPIFFS.h
@@ -17,6 +17,7 @@ class File {
 
   operator bool() const;
   String readString();
+  String readStringUntil(char terminator);
   size_t write(uint8_t c);
   size_t write(const uint8_t* buf, size_t size);
   size_t print(const char* str);

--- a/test/spiffs_gtest.cpp
+++ b/test/spiffs_gtest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "FS.h"
 #include "LittleFS.h"
 #include "SPIFFS.h"
 
@@ -124,4 +125,48 @@ TEST_F(SPIFFSTest, LittleFSAlias) {
   File f = LittleFS.open("/fs.txt", FILE_READ);
   EXPECT_TRUE(static_cast<bool>(f));
   EXPECT_STREQ(f.readString().c_str(), "littlefs");
+}
+
+TEST_F(SPIFFSTest, ReadStringUntilStopsAtDelimiter) {
+  SPIFFS.addFile("/delim.txt", "hello|world");
+  File f = SPIFFS.open("/delim.txt", FILE_READ);
+  String result = f.readStringUntil('|');
+  EXPECT_STREQ(result.c_str(), "hello");
+}
+
+TEST_F(SPIFFSTest, ReadStringUntilNewlineReturnsFirstLine) {
+  SPIFFS.addFile("/lines.txt", "line1\nline2\nline3");
+  File f = SPIFFS.open("/lines.txt", FILE_READ);
+  String result = f.readStringUntil('\n');
+  EXPECT_STREQ(result.c_str(), "line1");
+}
+
+TEST_F(SPIFFSTest, ReadStringUntilAtEofReturnsRemaining) {
+  SPIFFS.addFile("/eof.txt", "abc");
+  File f = SPIFFS.open("/eof.txt", FILE_READ);
+  // Read past first byte so we're mid-stream, then read until '\n' (not present)
+  f.read();  // consume 'a'
+  String result = f.readStringUntil('\n');
+  EXPECT_STREQ(result.c_str(), "bc");
+}
+
+TEST_F(SPIFFSTest, ReadStringUntilDelimiterNotPresentReturnsFullContent) {
+  SPIFFS.addFile("/full.txt", "no delimiter here");
+  File f = SPIFFS.open("/full.txt", FILE_READ);
+  String result = f.readStringUntil('|');
+  EXPECT_STREQ(result.c_str(), "no delimiter here");
+}
+
+TEST_F(SPIFFSTest, FSHeaderIncludeCompiles) {
+  // This test verifies that including FS.h (which re-exports SPIFFS.h) compiles
+  // and the File/MockSPIFFS types are accessible via that include path.
+  SPIFFS.addFile("/fstest.txt", "via FS.h");
+  File f = SPIFFS.open("/fstest.txt", FILE_READ);
+  EXPECT_TRUE(static_cast<bool>(f));
+  EXPECT_STREQ(f.readString().c_str(), "via FS.h");
+}
+
+TEST_F(SPIFFSTest, LittleFSBeginFormatOnFailReturnsTrue) {
+  LittleFS.reset();
+  EXPECT_TRUE(LittleFS.begin(true));
 }


### PR DESCRIPTION
## Summary
Fixes #71

- `src/SPIFFS.h/cpp` — adds `File::readStringUntil(char terminator)`
- `src/FS.h` — new redirect header (`#include "SPIFFS.h"`) for ESP32 Arduino Core compatibility
- 6 new tests: delimiter stops read, newline splits lines, EOF fallback, delimiter-not-present, FS.h include, `LittleFS.begin(true)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)