### PR TITLE
feat: GPIO interrupt system — pin state bus, attachInterrupt, mockSetPinState

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -40,44 +40,56 @@ typedef uint16_t word;
 #endif
 
 // Interrupt trigger modes
+#ifndef CHANGE
 #define CHANGE 2
+#endif
+#ifndef RISING
 #define RISING 3
+#endif
+#ifndef FALLING
 #define FALLING 4
+#endif
 
 #include <functional>
 #include <unordered_map>
 
 namespace mock {
 
-inline uint8_t pin_state[256] = {};
-
 struct IsrEntry {
   std::function<void()> callback;
   uint8_t mode;
 };
 
-inline std::unordered_map<uint8_t, IsrEntry> isr_table;
+inline uint8_t* pin_state() {
+  static uint8_t s[256] = {};
+  return s;
+}
+
+inline std::unordered_map<uint8_t, IsrEntry>& isr_table() {
+  static std::unordered_map<uint8_t, IsrEntry> t;
+  return t;
+}
 
 }  // namespace mock
 
 inline void pinMode(uint8_t /*pin*/, uint8_t /*mode*/) {}
-inline void digitalWrite(uint8_t pin, uint8_t val) { mock::pin_state[pin] = val; }
-inline int digitalRead(uint8_t pin) { return mock::pin_state[pin]; }
+inline void digitalWrite(uint8_t pin, uint8_t val) { mock::pin_state()[pin] = val; }
+inline int digitalRead(uint8_t pin) { return mock::pin_state()[pin]; }
 
 inline void attachInterrupt(uint8_t pin, std::function<void()> isr, uint8_t mode) {
-  mock::isr_table[pin] = {std::move(isr), mode};
+  mock::isr_table()[pin] = {std::move(isr), mode};
 }
-inline void detachInterrupt(uint8_t pin) { mock::isr_table.erase(pin); }
+inline void detachInterrupt(uint8_t pin) { mock::isr_table().erase(pin); }
 inline uint8_t digitalPinToInterrupt(uint8_t pin) { return pin; }
 
 /// Set a pin's logic level and fire any registered ISR according to its mode.
 /// Use this from tests or a simulator to inject physical pin events.
 inline void mockSetPinState(uint8_t pin, uint8_t value) {
-  uint8_t prev = mock::pin_state[pin];
-  mock::pin_state[pin] = value;
+  uint8_t prev = mock::pin_state()[pin];
+  mock::pin_state()[pin] = value;
 
-  auto it = mock::isr_table.find(pin);
-  if (it == mock::isr_table.end()) return;
+  auto it = mock::isr_table().find(pin);
+  if (it == mock::isr_table().end()) return;
 
   const auto& entry = it->second;
   bool fire = false;
@@ -102,8 +114,8 @@ inline void mockSetPinState(uint8_t pin, uint8_t value) {
 
 /// Reset all pin states and clear the interrupt table. Call in SetUp().
 inline void mockResetGpio() {
-  std::fill(std::begin(mock::pin_state), std::end(mock::pin_state), 0);
-  mock::isr_table.clear();
+  std::fill(mock::pin_state(), mock::pin_state() + 256, 0);
+  mock::isr_table().clear();
 }
 
 #include "Esp.h"

--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -21,7 +21,7 @@ typedef uint16_t word;
 #define OCT 8
 #define BIN 2
 
-// GPIO pin modes
+// GPIO pin modes and levels
 #ifndef INPUT
 #define INPUT 0x0
 #endif
@@ -32,9 +32,79 @@ typedef uint16_t word;
 #define INPUT_PULLUP 0x2
 #endif
 
+#ifndef LOW
+#define LOW 0
+#endif
+#ifndef HIGH
+#define HIGH 1
+#endif
+
+// Interrupt trigger modes
+#define CHANGE 2
+#define RISING 3
+#define FALLING 4
+
+#include <functional>
+#include <unordered_map>
+
+namespace mock {
+
+inline uint8_t pin_state[256] = {};
+
+struct IsrEntry {
+  std::function<void()> callback;
+  uint8_t mode;
+};
+
+inline std::unordered_map<uint8_t, IsrEntry> isr_table;
+
+}  // namespace mock
+
 inline void pinMode(uint8_t /*pin*/, uint8_t /*mode*/) {}
-inline void digitalWrite(uint8_t /*pin*/, uint8_t /*val*/) {}
-inline int digitalRead(uint8_t /*pin*/) { return 0; }
+inline void digitalWrite(uint8_t pin, uint8_t val) { mock::pin_state[pin] = val; }
+inline int digitalRead(uint8_t pin) { return mock::pin_state[pin]; }
+
+inline void attachInterrupt(uint8_t pin, std::function<void()> isr, uint8_t mode) {
+  mock::isr_table[pin] = {std::move(isr), mode};
+}
+inline void detachInterrupt(uint8_t pin) { mock::isr_table.erase(pin); }
+inline uint8_t digitalPinToInterrupt(uint8_t pin) { return pin; }
+
+/// Set a pin's logic level and fire any registered ISR according to its mode.
+/// Use this from tests or a simulator to inject physical pin events.
+inline void mockSetPinState(uint8_t pin, uint8_t value) {
+  uint8_t prev = mock::pin_state[pin];
+  mock::pin_state[pin] = value;
+
+  auto it = mock::isr_table.find(pin);
+  if (it == mock::isr_table.end()) return;
+
+  const auto& entry = it->second;
+  bool fire = false;
+  switch (entry.mode) {
+    case CHANGE:
+      fire = (prev != value);
+      break;
+    case RISING:
+      fire = (prev == LOW && value == HIGH);
+      break;
+    case FALLING:
+      fire = (prev == HIGH && value == LOW);
+      break;
+    case LOW:
+      fire = (value == LOW);
+      break;
+    default:
+      break;
+  }
+  if (fire && entry.callback) entry.callback();
+}
+
+/// Reset all pin states and clear the interrupt table. Call in SetUp().
+inline void mockResetGpio() {
+  std::fill(std::begin(mock::pin_state), std::end(mock::pin_state), 0);
+  mock::isr_table.clear();
+}
 
 #include "Esp.h"
 #include "HardwareSerial.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_GTEST_TESTS)
     add_test(NAME ${name} COMMAND ${name})
   endfunction()
 
+  add_gtest(gpio_interrupt_gtest gpio_interrupt_gtest.cpp)
   add_gtest(queue_gtest queue_gtest.cpp)
   add_gtest(semaphore_gtest semaphore_gtest.cpp)
   add_gtest(task_gtest task_gtest.cpp)

--- a/test/gpio_interrupt_gtest.cpp
+++ b/test/gpio_interrupt_gtest.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+
+#include "Arduino.h"
+
+class GpioTest : public ::testing::Test {
+ protected:
+  void SetUp() override { mockResetGpio(); }
+};
+
+// --- digitalWrite / digitalRead state persistence -------------------------
+
+TEST_F(GpioTest, DigitalWriteRead_Roundtrip) {
+  digitalWrite(5, HIGH);
+  EXPECT_EQ(HIGH, digitalRead(5));
+}
+
+TEST_F(GpioTest, DigitalRead_DefaultLow) { EXPECT_EQ(LOW, digitalRead(42)); }
+
+TEST_F(GpioTest, DigitalWrite_MultiplePinsIndependent) {
+  digitalWrite(1, HIGH);
+  digitalWrite(2, LOW);
+  digitalWrite(3, HIGH);
+  EXPECT_EQ(HIGH, digitalRead(1));
+  EXPECT_EQ(LOW, digitalRead(2));
+  EXPECT_EQ(HIGH, digitalRead(3));
+}
+
+TEST_F(GpioTest, DigitalWrite_OverwritesPreviousValue) {
+  digitalWrite(7, HIGH);
+  digitalWrite(7, LOW);
+  EXPECT_EQ(LOW, digitalRead(7));
+}
+
+// --- mockResetGpio --------------------------------------------------------
+
+TEST_F(GpioTest, MockResetGpio_ClearsPinState) {
+  digitalWrite(10, HIGH);
+  mockResetGpio();
+  EXPECT_EQ(LOW, digitalRead(10));
+}
+
+// --- attachInterrupt / detachInterrupt ------------------------------------
+
+TEST_F(GpioTest, AttachInterrupt_RegistersCallback) {
+  int fired = 0;
+  attachInterrupt(4, [&fired]() { fired++; }, RISING);
+  mockSetPinState(4, HIGH);
+  EXPECT_EQ(1, fired);
+}
+
+TEST_F(GpioTest, DetachInterrupt_StopsFiring) {
+  int fired = 0;
+  attachInterrupt(4, [&fired]() { fired++; }, RISING);
+  detachInterrupt(4);
+  mockSetPinState(4, HIGH);
+  EXPECT_EQ(0, fired);
+}
+
+TEST_F(GpioTest, DigitalPinToInterrupt_IdentityMapping) {
+  EXPECT_EQ(13u, digitalPinToInterrupt(13));
+}
+
+// --- mockSetPinState / RISING ---------------------------------------------
+
+TEST_F(GpioTest, Rising_FiresOnLowToHigh) {
+  int fired = 0;
+  attachInterrupt(2, [&fired]() { fired++; }, RISING);
+  mockSetPinState(2, HIGH);
+  EXPECT_EQ(1, fired);
+}
+
+TEST_F(GpioTest, Rising_DoesNotFireOnHighToLow) {
+  int fired = 0;
+  attachInterrupt(2, [&fired]() { fired++; }, RISING);
+  mockSetPinState(2, HIGH);  // LOW→HIGH: fires
+  fired = 0;
+  mockSetPinState(2, LOW);  // HIGH→LOW: must not fire
+  EXPECT_EQ(0, fired);
+}
+
+TEST_F(GpioTest, Rising_DoesNotFireWhenAlreadyHigh) {
+  int fired = 0;
+  digitalWrite(2, HIGH);
+  attachInterrupt(2, [&fired]() { fired++; }, RISING);
+  mockSetPinState(2, HIGH);  // HIGH→HIGH: no edge
+  EXPECT_EQ(0, fired);
+}
+
+// --- mockSetPinState / FALLING --------------------------------------------
+
+TEST_F(GpioTest, Falling_FiresOnHighToLow) {
+  int fired = 0;
+  digitalWrite(3, HIGH);
+  attachInterrupt(3, [&fired]() { fired++; }, FALLING);
+  mockSetPinState(3, LOW);
+  EXPECT_EQ(1, fired);
+}
+
+TEST_F(GpioTest, Falling_DoesNotFireOnLowToHigh) {
+  int fired = 0;
+  attachInterrupt(3, [&fired]() { fired++; }, FALLING);
+  mockSetPinState(3, HIGH);  // LOW→HIGH: must not fire
+  EXPECT_EQ(0, fired);
+}
+
+// --- mockSetPinState / CHANGE ---------------------------------------------
+
+TEST_F(GpioTest, Change_FiresOnLowToHigh) {
+  int fired = 0;
+  attachInterrupt(5, [&fired]() { fired++; }, CHANGE);
+  mockSetPinState(5, HIGH);
+  EXPECT_EQ(1, fired);
+}
+
+TEST_F(GpioTest, Change_FiresOnHighToLow) {
+  int fired = 0;
+  digitalWrite(5, HIGH);
+  attachInterrupt(5, [&fired]() { fired++; }, CHANGE);
+  mockSetPinState(5, LOW);
+  EXPECT_EQ(1, fired);
+}
+
+TEST_F(GpioTest, Change_DoesNotFireWhenValueUnchanged) {
+  int fired = 0;
+  attachInterrupt(5, [&fired]() { fired++; }, CHANGE);
+  mockSetPinState(5, LOW);  // LOW→LOW: no change
+  EXPECT_EQ(0, fired);
+}
+
+// --- mockSetPinState / LOW ------------------------------------------------
+
+TEST_F(GpioTest, LowMode_FiresWhenPinIsLow) {
+  int fired = 0;
+  attachInterrupt(6, [&fired]() { fired++; }, LOW);
+  mockSetPinState(6, LOW);
+  EXPECT_EQ(1, fired);
+}
+
+TEST_F(GpioTest, LowMode_DoesNotFireWhenPinIsHigh) {
+  int fired = 0;
+  attachInterrupt(6, [&fired]() { fired++; }, LOW);
+  mockSetPinState(6, HIGH);
+  EXPECT_EQ(0, fired);
+}
+
+// --- mockSetPinState updates pin state ------------------------------------
+
+TEST_F(GpioTest, MockSetPinState_UpdatesReadableState) {
+  mockSetPinState(9, HIGH);
+  EXPECT_EQ(HIGH, digitalRead(9));
+  mockSetPinState(9, LOW);
+  EXPECT_EQ(LOW, digitalRead(9));
+}
+
+// --- multiple pins are independent ----------------------------------------
+
+TEST_F(GpioTest, MultipleInterrupts_IndependentFiring) {
+  int fired_a = 0, fired_b = 0;
+  attachInterrupt(10, [&fired_a]() { fired_a++; }, RISING);
+  attachInterrupt(11, [&fired_b]() { fired_b++; }, RISING);
+  mockSetPinState(10, HIGH);
+  EXPECT_EQ(1, fired_a);
+  EXPECT_EQ(0, fired_b);
+  mockSetPinState(11, HIGH);
+  EXPECT_EQ(1, fired_a);
+  EXPECT_EQ(1, fired_b);
+}
+
+// --- mockResetGpio clears isr_table ---------------------------------------
+
+TEST_F(GpioTest, MockResetGpio_ClearsIsrTable) {
+  int fired = 0;
+  attachInterrupt(12, [&fired]() { fired++; }, RISING);
+  mockResetGpio();
+  mockSetPinState(12, HIGH);
+  EXPECT_EQ(0, fired);
+}

--- a/test/missing_apis_gtest.cpp
+++ b/test/missing_apis_gtest.cpp
@@ -55,4 +55,7 @@ TEST(GpioConstants, PinModeDoesNotThrow) { EXPECT_NO_THROW(pinMode(4, OUTPUT)); 
 
 TEST(GpioConstants, DigitalWriteDoesNotThrow) { EXPECT_NO_THROW(digitalWrite(4, 1)); }
 
-TEST(GpioConstants, DigitalReadReturnsZero) { EXPECT_EQ(digitalRead(4), 0); }
+TEST(GpioConstants, DigitalReadReturnsZero) {
+  mockResetGpio();
+  EXPECT_EQ(0, digitalRead(4));
+}


### PR DESCRIPTION
Closes #87

## Summary

- `HIGH`/`LOW` pin level constants and `CHANGE`/`RISING`/`FALLING` interrupt mode constants added to `Arduino.h`
- `digitalRead`/`digitalWrite` now backed by `mock::pin_state[256]` — state persists across calls (replaces no-op stubs)
- `attachInterrupt(pin, std::function<void()>, mode)` / `detachInterrupt` / `digitalPinToInterrupt` — accepts capturing lambdas as well as plain function pointers
- `mockSetPinState(pin, value)` — sets pin level and fires the registered ISR according to its mode (RISING / FALLING / CHANGE / LOW); this is the control surface for simulators
- `mockResetGpio()` — clears all pin state and the ISR table; call in `SetUp()`
- 21 new tests in `gpio_interrupt_gtest.cpp`
- Fix `missing_apis_gtest`: `DigitalReadReturnsZero` now calls `mockResetGpio()` since `digitalRead` is no longer a constant-zero stub

## Test plan

- [x] `gpio_interrupt_gtest` — 21 tests covering all trigger modes, multi-pin independence, detach, and reset
- [x] `missing_apis_gtest` — pre-existing GPIO tests still pass
- [x] Full test suite passes