### PR TITLE
feat: add getNextTrigger and writeNextTrigger to AlarmClass

### DIFF
--- a/src/TimeAlarms.h
+++ b/src/TimeAlarms.h
@@ -81,9 +81,12 @@ class AlarmClass {
 
   void writeNextTrigger(AlarmID_t id, time_t timestamp) {
     if (id >= MAX_ALARMS) return;
-    auto secs = static_cast<long>(timestamp) - static_cast<long>(std::time(nullptr));
-    _alarms[id].nextFire =
-        std::chrono::steady_clock::now() + std::chrono::seconds(secs > 0 ? secs : 0);
+    const time_t nowTime = std::time(nullptr);
+    const auto steadyNow = std::chrono::steady_clock::now();
+    using SecondsRep = std::chrono::seconds::rep;
+    SecondsRep secs = 0;
+    if (timestamp > nowTime) { secs = static_cast<SecondsRep>(timestamp - nowTime); }
+    _alarms[id].nextFire = steadyNow + std::chrono::seconds(secs);
   }
 
   void reset() {

--- a/src/TimeAlarms.h
+++ b/src/TimeAlarms.h
@@ -2,6 +2,7 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <ctime>
 #include <functional>
 #include <thread>
 
@@ -69,6 +70,20 @@ class AlarmClass {
       tick();
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
+  }
+
+  time_t getNextTrigger(AlarmID_t id) const {
+    if (id >= MAX_ALARMS || !_alarms[id].enabled) return 0;
+    auto remaining = _alarms[id].nextFire - std::chrono::steady_clock::now();
+    auto secs = std::chrono::duration_cast<std::chrono::seconds>(remaining).count();
+    return static_cast<time_t>(std::time(nullptr) + (secs > 0 ? secs : 0));
+  }
+
+  void writeNextTrigger(AlarmID_t id, time_t timestamp) {
+    if (id >= MAX_ALARMS) return;
+    auto secs = static_cast<long>(timestamp) - static_cast<long>(std::time(nullptr));
+    _alarms[id].nextFire =
+        std::chrono::steady_clock::now() + std::chrono::seconds(secs > 0 ? secs : 0);
   }
 
   void reset() {

--- a/test/time_alarms_gtest.cpp
+++ b/test/time_alarms_gtest.cpp
@@ -112,3 +112,47 @@ TEST(TimeAlarmsTest, TimerOnceFiresOnlyOnce) {
   Alarm.delay(20);
   EXPECT_EQ(count, 1);
 }
+
+// --- getNextTrigger / writeNextTrigger ---
+
+TEST(TimeAlarmsTest, GetNextTriggerReturnsFutureForFreshAlarm) {
+  Alarm.reset();
+  AlarmID_t id = Alarm.timerRepeat(10, nullptr);
+  time_t trigger = Alarm.getNextTrigger(id);
+  EXPECT_GE(trigger, std::time(nullptr));
+}
+
+TEST(TimeAlarmsTest, GetNextTriggerReturnsZeroForInvalidId) {
+  Alarm.reset();
+  EXPECT_EQ(Alarm.getNextTrigger(255), 0);
+}
+
+TEST(TimeAlarmsTest, GetNextTriggerReturnsZeroForDisabledAlarm) {
+  Alarm.reset();
+  AlarmID_t id = Alarm.timerRepeat(10, nullptr);
+  Alarm.disable(id);
+  EXPECT_EQ(Alarm.getNextTrigger(id), 0);
+}
+
+TEST(TimeAlarmsTest, WriteNextTriggerRoundTrip) {
+  Alarm.reset();
+  AlarmID_t id = Alarm.timerRepeat(100, nullptr);
+  time_t future = std::time(nullptr) + 10;
+  Alarm.writeNextTrigger(id, future);
+  time_t result = Alarm.getNextTrigger(id);
+  EXPECT_GE(result, future - 2);
+  EXPECT_LE(result, future + 2);
+}
+
+TEST(TimeAlarmsTest, WriteNextTriggerPastTimestampClampsToNow) {
+  Alarm.reset();
+  AlarmID_t id = Alarm.timerRepeat(100, nullptr);
+  time_t past = std::time(nullptr) - 100;
+  Alarm.writeNextTrigger(id, past);
+  EXPECT_GE(Alarm.getNextTrigger(id), std::time(nullptr));
+}
+
+TEST(TimeAlarmsTest, WriteNextTriggerOutOfRangeIdDoesNotCrash) {
+  Alarm.reset();
+  EXPECT_NO_THROW(Alarm.writeNextTrigger(255, std::time(nullptr) + 10));
+}

--- a/test/time_alarms_gtest.cpp
+++ b/test/time_alarms_gtest.cpp
@@ -124,7 +124,7 @@ TEST(TimeAlarmsTest, GetNextTriggerReturnsFutureForFreshAlarm) {
 
 TEST(TimeAlarmsTest, GetNextTriggerReturnsZeroForInvalidId) {
   Alarm.reset();
-  EXPECT_EQ(Alarm.getNextTrigger(255), 0);
+  EXPECT_EQ(Alarm.getNextTrigger(dtINVALID_ALARM_ID), 0);
 }
 
 TEST(TimeAlarmsTest, GetNextTriggerReturnsZeroForDisabledAlarm) {
@@ -148,11 +148,12 @@ TEST(TimeAlarmsTest, WriteNextTriggerPastTimestampClampsToNow) {
   Alarm.reset();
   AlarmID_t id = Alarm.timerRepeat(100, nullptr);
   time_t past = std::time(nullptr) - 100;
+  time_t now = std::time(nullptr);
   Alarm.writeNextTrigger(id, past);
-  EXPECT_GE(Alarm.getNextTrigger(id), std::time(nullptr));
+  EXPECT_GE(Alarm.getNextTrigger(id), now);
 }
 
 TEST(TimeAlarmsTest, WriteNextTriggerOutOfRangeIdDoesNotCrash) {
   Alarm.reset();
-  EXPECT_NO_THROW(Alarm.writeNextTrigger(255, std::time(nullptr) + 10));
+  EXPECT_NO_THROW(Alarm.writeNextTrigger(dtINVALID_ALARM_ID, std::time(nullptr) + 10));
 }


### PR DESCRIPTION
## Summary

- Add `getNextTrigger(AlarmID_t id) const` — returns the next scheduled wall-clock `time_t` for an alarm by converting from the internal `steady_clock` domain; returns 0 for invalid or disabled alarms
- Add `writeNextTrigger(AlarmID_t id, time_t timestamp)` — overwrites the next fire time from a persisted wall-clock timestamp; clamps past timestamps to now

Both methods go in the `public:` section of `AlarmClass` in `src/TimeAlarms.h`.

Closes #90

## Test plan (added to existing `time_alarms_gtest.cpp`)

- [x] `getNextTrigger` returns a future value for a freshly created alarm
- [x] `getNextTrigger` returns 0 for invalid id (255)
- [x] `getNextTrigger` returns 0 for a disabled alarm
- [x] `writeNextTrigger` / `getNextTrigger` round-trip within ±2s window
- [x] `writeNextTrigger` with past timestamp clamps to now (result >= now)
- [x] `writeNextTrigger` with out-of-range id does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)