### PR TITLE
feat: LittleFS/SPIFFS mock gaps — end(), String overloads, openNextFile(), F()/PSTR()

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -147,6 +147,15 @@ inline long map(long x, long in_min, long in_max, long out_min, long out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
+// Flash-string helpers — no-ops on native
+class __FlashStringHelper;
+#ifndef PSTR
+#define PSTR(s) (s)
+#endif
+#ifndef F
+#define F(s) (reinterpret_cast<const __FlashStringHelper*>(PSTR(s)))
+#endif
+
 #include "Stream.h"
 #include "TimeLib.h"
 #include "WString.h"

--- a/src/SPIFFS.cpp
+++ b/src/SPIFFS.cpp
@@ -86,7 +86,10 @@ void File::close() {
 
 // --- MockSPIFFS implementation ---
 
-bool MockSPIFFS::begin(bool) { return _mounted; }
+bool MockSPIFFS::begin(bool) {
+  if (_canMount) _mounted = true;
+  return _canMount;
+}
 
 bool MockSPIFFS::begin(bool formatOnFail, const char*, uint8_t) { return begin(formatOnFail); }
 

--- a/src/SPIFFS.cpp
+++ b/src/SPIFFS.cpp
@@ -69,6 +69,12 @@ int File::available() {
   return static_cast<int>(_contentPtr->size() - _readPos);
 }
 
+size_t File::print(const String& str) { return print(str.c_str()); }
+
+size_t File::println(const String& str) { return println(str.c_str()); }
+
+File File::openNextFile() { return File(); }
+
 String File::name() { return String(_name.c_str()); }
 
 size_t File::size() { return _contentPtr ? _contentPtr->size() : 0; }
@@ -81,6 +87,10 @@ void File::close() {
 // --- MockSPIFFS implementation ---
 
 bool MockSPIFFS::begin(bool) { return _mounted; }
+
+bool MockSPIFFS::begin(bool formatOnFail, const char*, uint8_t) { return begin(formatOnFail); }
+
+void MockSPIFFS::end() { _mounted = false; }
 
 File MockSPIFFS::open(const char* path, const char* mode) {
   std::string m = mode ? mode : FILE_READ;
@@ -102,11 +112,17 @@ File MockSPIFFS::open(const char* path, const char* mode) {
 
 bool MockSPIFFS::exists(const char* path) { return _files.count(path) > 0; }
 
+bool MockSPIFFS::exists(const String& path) { return exists(path.c_str()); }
+
+File MockSPIFFS::open(const String& path, const char* mode) { return open(path.c_str(), mode); }
+
 bool MockSPIFFS::remove(const char* path) {
   if (!_files.count(path)) return false;
   _files.erase(path);
   return true;
 }
+
+bool MockSPIFFS::remove(const String& path) { return remove(path.c_str()); }
 
 bool MockSPIFFS::rename(const char* from, const char* to) {
   if (!_files.count(from)) return false;

--- a/src/SPIFFS.h
+++ b/src/SPIFFS.h
@@ -54,18 +54,20 @@ class MockSPIFFS {
   bool rename(const char* from, const char* to);
 
   // Test helpers
-  void setMounted(bool v) { _mounted = v; }
+  void setMounted(bool v) { _canMount = v; }
   void addFile(const char* path, const std::string& content) { _files[path] = content; }
   std::string getFile(const char* path) { return _files.count(path) ? _files[path] : ""; }
   void clear() { _files.clear(); }
   void reset() {
     _files.clear();
-    _mounted = true;
+    _mounted = false;
+    _canMount = true;
   }
 
  private:
   std::map<std::string, std::string> _files;
-  bool _mounted = true;
+  bool _mounted = false;
+  bool _canMount = true;
   friend class File;
 };
 

--- a/src/SPIFFS.h
+++ b/src/SPIFFS.h
@@ -22,9 +22,12 @@ class File {
   size_t write(const uint8_t* buf, size_t size);
   size_t print(const char* str);
   size_t println(const char* str);
+  size_t print(const String& str);
+  size_t println(const String& str);
   int read();
   int peek();
   int available();
+  File openNextFile();
   String name();
   size_t size();
   void close();
@@ -40,9 +43,14 @@ class File {
 class MockSPIFFS {
  public:
   bool begin(bool formatOnFail = false);
+  bool begin(bool formatOnFail, const char* basePath, uint8_t maxFiles = 10);
+  void end();
   File open(const char* path, const char* mode = FILE_READ);
+  File open(const String& path, const char* mode = FILE_READ);
   bool exists(const char* path);
+  bool exists(const String& path);
   bool remove(const char* path);
+  bool remove(const String& path);
   bool rename(const char* from, const char* to);
 
   // Test helpers

--- a/test/spiffs_gtest.cpp
+++ b/test/spiffs_gtest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "Arduino.h"
 #include "FS.h"
 #include "LittleFS.h"
 #include "SPIFFS.h"
@@ -169,4 +170,91 @@ TEST_F(SPIFFSTest, FSHeaderIncludeCompiles) {
 TEST_F(SPIFFSTest, LittleFSBeginFormatOnFailReturnsTrue) {
   LittleFS.reset();
   EXPECT_TRUE(LittleFS.begin(true));
+}
+
+// --- end() ---
+
+TEST_F(SPIFFSTest, EndSetsMountedFalse) {
+  EXPECT_TRUE(SPIFFS.begin());
+  SPIFFS.end();
+  EXPECT_FALSE(SPIFFS.begin());
+}
+
+// --- begin(bool, const char*, uint8_t) ---
+
+TEST_F(SPIFFSTest, ThreeArgBeginReturnsTrue) { EXPECT_TRUE(SPIFFS.begin(false, "/spiffs", 10)); }
+
+TEST_F(SPIFFSTest, ThreeArgBeginRespectsMountedState) {
+  SPIFFS.setMounted(false);
+  EXPECT_FALSE(SPIFFS.begin(false, "/spiffs", 10));
+}
+
+// --- open(String) ---
+
+TEST_F(SPIFFSTest, OpenWithStringPath) {
+  SPIFFS.addFile("/cfg.json", "{}");
+  File f = SPIFFS.open(String("/cfg.json"), FILE_READ);
+  EXPECT_TRUE(static_cast<bool>(f));
+  EXPECT_STREQ(f.readString().c_str(), "{}");
+}
+
+TEST_F(SPIFFSTest, OpenWithStringPathWriteMode) {
+  File f = SPIFFS.open(String("/new.txt"), FILE_WRITE);
+  EXPECT_TRUE(static_cast<bool>(f));
+  f.print("data");
+  f.close();
+  EXPECT_STREQ(SPIFFS.getFile("/new.txt").c_str(), "data");
+}
+
+// --- exists(String) ---
+
+TEST_F(SPIFFSTest, ExistsWithStringPath) {
+  SPIFFS.addFile("/x.txt", "");
+  EXPECT_TRUE(SPIFFS.exists(String("/x.txt")));
+  EXPECT_FALSE(SPIFFS.exists(String("/y.txt")));
+}
+
+// --- remove(String) ---
+
+TEST_F(SPIFFSTest, RemoveWithStringPath) {
+  SPIFFS.addFile("/del.txt", "bye");
+  EXPECT_TRUE(SPIFFS.remove(String("/del.txt")));
+  EXPECT_FALSE(SPIFFS.exists("/del.txt"));
+}
+
+// --- File::print(String) / println(String) ---
+
+TEST_F(SPIFFSTest, FilePrintString) {
+  File f = SPIFFS.open("/s.txt", FILE_WRITE);
+  f.print(String("hello"));
+  f.close();
+  EXPECT_STREQ(SPIFFS.getFile("/s.txt").c_str(), "hello");
+}
+
+TEST_F(SPIFFSTest, FilePrintlnString) {
+  File f = SPIFFS.open("/sl.txt", FILE_WRITE);
+  f.println(String("hello"));
+  f.close();
+  EXPECT_STREQ(SPIFFS.getFile("/sl.txt").c_str(), "hello\n");
+}
+
+// --- File::openNextFile() ---
+
+TEST_F(SPIFFSTest, OpenNextFileReturnsInvalidFile) {
+  SPIFFS.addFile("/dir/", "");
+  File dir = SPIFFS.open("/dir/", FILE_READ);
+  File entry = dir.openNextFile();
+  EXPECT_FALSE(static_cast<bool>(entry));
+}
+
+// --- F() / PSTR() ---
+
+TEST_F(SPIFFSTest, PSTRMacroIsIdentity) {
+  const char* s = PSTR("hello");
+  EXPECT_STREQ(s, "hello");
+}
+
+TEST_F(SPIFFSTest, FMacroCompilesAndPassesThrough) {
+  const __FlashStringHelper* fstr = F("world");
+  EXPECT_STREQ(reinterpret_cast<const char*>(fstr), "world");
 }

--- a/test/spiffs_gtest.cpp
+++ b/test/spiffs_gtest.cpp
@@ -174,10 +174,10 @@ TEST_F(SPIFFSTest, LittleFSBeginFormatOnFailReturnsTrue) {
 
 // --- end() ---
 
-TEST_F(SPIFFSTest, EndSetsMountedFalse) {
+TEST_F(SPIFFSTest, EndAllowsRemounting) {
   EXPECT_TRUE(SPIFFS.begin());
   SPIFFS.end();
-  EXPECT_FALSE(SPIFFS.begin());
+  EXPECT_TRUE(SPIFFS.begin());  // end() doesn't prevent remounting
 }
 
 // --- begin(bool, const char*, uint8_t) ---


### PR DESCRIPTION
Closes #99

## Summary

- `MockSPIFFS`: `end()`, `begin(bool, const char*, uint8_t)` 3-arg overload, `open/exists/remove(const String&)` overloads
- `File`: `openNextFile()` returning empty `File` (signals end-of-dir), `print(const String&)`, `println(const String&)`
- `Arduino.h`: `PSTR(s)` and `F(s)` flash-string no-op macros with `__FlashStringHelper` forward-decl
- 12 new tests added to `spiffs_gtest.cpp` (34 total, all passing)

## Test plan

- [ ] CI green
- [ ] All 34 `SPIFFSTest` cases pass
- [ ] `F()`/`PSTR()` compile and behave as identity on native

🤖 Generated with [Claude Code](https://claude.com/claude-code)