### PR TITLE
feat: Add setTimeout, readBytes, readBytesUntil, parseInt, parseFloat to Stream

### DIFF
--- a/src/Stream.h
+++ b/src/Stream.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cctype>
+
 #include "Print.h"
 #include "times.h"
 
@@ -41,5 +43,69 @@ class Stream : public Print {
       result += static_cast<char>(c);
     }
     return result;
+  }
+
+  void setTimeout(unsigned long timeout) { _timeout = timeout; }
+  unsigned long getTimeout() const { return _timeout; }
+
+  size_t readBytes(char* buffer, size_t length) {
+    size_t count = 0;
+    while (count < length) {
+      int c = timedRead();
+      if (c < 0) break;
+      buffer[count++] = static_cast<char>(c);
+    }
+    return count;
+  }
+
+  size_t readBytesUntil(char terminator, char* buffer, size_t length) {
+    size_t count = 0;
+    while (count < length) {
+      int c = timedRead();
+      if (c < 0 || static_cast<char>(c) == terminator) break;
+      buffer[count++] = static_cast<char>(c);
+    }
+    return count;
+  }
+
+  long parseInt() {
+    bool negative = false;
+    long value = 0;
+    int c;
+    while ((c = timedRead()) >= 0 && !isdigit(c) && c != '-') {}
+    if (c == '-') {
+      negative = true;
+      c = timedRead();
+    }
+    while (c >= 0 && isdigit(c)) {
+      value = value * 10 + (c - '0');
+      c = timedRead();
+    }
+    return negative ? -value : value;
+  }
+
+  float parseFloat() {
+    bool negative = false;
+    float value = 0.0f;
+    float fraction = 1.0f;
+    bool inFraction = false;
+    int c;
+    while ((c = timedRead()) >= 0 && !isdigit(c) && c != '-' && c != '.') {}
+    if (c == '-') {
+      negative = true;
+      c = timedRead();
+    }
+    while (c >= 0 && (isdigit(c) || c == '.')) {
+      if (c == '.') {
+        inFraction = true;
+      } else if (!inFraction) {
+        value = value * 10.0f + static_cast<float>(c - '0');
+      } else {
+        fraction *= 0.1f;
+        value += static_cast<float>(c - '0') * fraction;
+      }
+      c = timedRead();
+    }
+    return negative ? -value : value;
   }
 };

--- a/test/hardware_serial_gtest.cpp
+++ b/test/hardware_serial_gtest.cpp
@@ -211,3 +211,93 @@ TEST(HardwareSerialTest, GlobalSerialInstances) {
   Serial2.reset();
   Serial3.reset();
 }
+
+// --- Stream read methods ---
+
+TEST(StreamReadTest, SetAndGetTimeout) {
+  HardwareSerial s(0);
+  s.setTimeout(500);
+  EXPECT_EQ(s.getTimeout(), 500UL);
+}
+
+TEST(StreamReadTest, ReadBytesReadsAvailableData) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("hello");
+  char buf[8] = {};
+  size_t n = s.readBytes(buf, 5);
+  EXPECT_EQ(n, 5u);
+  EXPECT_STREQ(buf, "hello");
+}
+
+TEST(StreamReadTest, ReadBytesStopsAtLength) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("abcdef");
+  char buf[8] = {};
+  size_t n = s.readBytes(buf, 3);
+  EXPECT_EQ(n, 3u);
+  EXPECT_EQ(buf[0], 'a');
+  EXPECT_EQ(buf[2], 'c');
+}
+
+TEST(StreamReadTest, ReadBytesUntilStopsAtTerminator) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("hello\nworld");
+  char buf[16] = {};
+  size_t n = s.readBytesUntil('\n', buf, sizeof(buf) - 1);
+  EXPECT_EQ(n, 5u);
+  EXPECT_STREQ(buf, "hello");
+}
+
+TEST(StreamReadTest, ReadBytesUntilStopsAtLength) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("abcdef");
+  char buf[4] = {};
+  size_t n = s.readBytesUntil('|', buf, 3);
+  EXPECT_EQ(n, 3u);
+}
+
+TEST(StreamReadTest, ParseIntPositive) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("42");
+  EXPECT_EQ(s.parseInt(), 42L);
+}
+
+TEST(StreamReadTest, ParseIntNegative) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("-17");
+  EXPECT_EQ(s.parseInt(), -17L);
+}
+
+TEST(StreamReadTest, ParseIntSkipsLeadingNonDigits) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("abc123");
+  EXPECT_EQ(s.parseInt(), 123L);
+}
+
+TEST(StreamReadTest, ParseFloatPositive) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("3.14");
+  EXPECT_NEAR(s.parseFloat(), 3.14f, 0.001f);
+}
+
+TEST(StreamReadTest, ParseFloatNegative) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("-2.5");
+  EXPECT_NEAR(s.parseFloat(), -2.5f, 0.001f);
+}
+
+TEST(StreamReadTest, ParseFloatInteger) {
+  HardwareSerial s(0);
+  s.setTimeout(0);
+  s.injectRxData("7");
+  EXPECT_NEAR(s.parseFloat(), 7.0f, 0.001f);
+}


### PR DESCRIPTION
Closes #106

## Summary

- `setTimeout(unsigned long)` / `getTimeout()` — set/get the read timeout
- `readBytes(char*, size_t)` — read up to N bytes via `timedRead()`
- `readBytesUntil(char, char*, size_t)` — read until terminator or N bytes
- `parseInt()` — skip non-digits, parse signed integer
- `parseFloat()` — skip non-numeric, parse signed float

All inline in `Stream.h`, building on existing `timedRead()` and `_timeout`.

## Test plan

- [ ] CI green
- [ ] 11 new `StreamReadTest` cases covering all methods (37 total in `hardware_serial_gtest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)