### PR TITLE
feat: Include esp32-hal-log.h from Arduino.h

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -124,6 +124,7 @@ inline void setToneChannel(uint8_t /*channel*/ = 0) {}
 
 #include "Esp.h"
 #include "HardwareSerial.h"
+#include "esp32-hal-log.h"
 // Arduino math macros
 #ifndef PI
 #define PI 3.14159265358979323846


### PR DESCRIPTION
Closes #107

## Summary

Adds `#include "esp32-hal-log.h"` to `Arduino.h` so that `log_e`/`log_i`/`log_w`/`log_d`/`log_v` are available to any file that includes `<Arduino.h>`, matching real ESP32 behaviour.

## Test plan
- [ ] CI green
- [ ] Existing `esp32_core_mocks_gtest` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)