### PR TITLE
feat: Add PROGMEM shims and analogRead/analogWrite stubs

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -19,11 +19,24 @@ typedef uint16_t word;
 #ifndef PROGMEM
 #define PROGMEM
 #endif
+
+#include <cstring>
+
+static inline uint8_t pgm_read_byte_impl(const void* addr) {
+  uint8_t v;
+  std::memcpy(&v, addr, sizeof(v));
+  return v;
+}
+static inline uint16_t pgm_read_word_impl(const void* addr) {
+  uint16_t v;
+  std::memcpy(&v, addr, sizeof(v));
+  return v;
+}
 #ifndef pgm_read_byte
-#define pgm_read_byte(addr) (*(const uint8_t*)(addr))
+#define pgm_read_byte(addr) ::pgm_read_byte_impl(reinterpret_cast<const void*>(addr))
 #endif
 #ifndef pgm_read_word
-#define pgm_read_word(addr) (*(const uint16_t*)(addr))
+#define pgm_read_word(addr) ::pgm_read_word_impl(reinterpret_cast<const void*>(addr))
 #endif
 
 #define DEC 10

--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -16,6 +16,16 @@ typedef bool boolean;
 typedef uint8_t byte;
 typedef uint16_t word;
 
+#ifndef PROGMEM
+#define PROGMEM
+#endif
+#ifndef pgm_read_byte
+#define pgm_read_byte(addr) (*(const uint8_t*)(addr))
+#endif
+#ifndef pgm_read_word
+#define pgm_read_word(addr) (*(const uint16_t*)(addr))
+#endif
+
 #define DEC 10
 #define HEX 16
 #define OCT 8
@@ -75,6 +85,8 @@ inline std::unordered_map<uint8_t, IsrEntry>& isr_table() {
 inline void pinMode(uint8_t /*pin*/, uint8_t /*mode*/) {}
 inline void digitalWrite(uint8_t pin, uint8_t val) { mock::pin_state()[pin] = val; }
 inline int digitalRead(uint8_t pin) { return mock::pin_state()[pin]; }
+inline int analogRead(uint8_t /*pin*/) { return 0; }
+inline void analogWrite(uint8_t /*pin*/, int /*value*/) {}
 
 inline void attachInterrupt(uint8_t pin, std::function<void()> isr, uint8_t mode) {
   mock::isr_table()[pin] = {std::move(isr), mode};

--- a/test/esp32_apis_gtest.cpp
+++ b/test/esp32_apis_gtest.cpp
@@ -89,5 +89,10 @@ TEST(ProgmemTest, PGMREADWordIsIdentity) {
   const uint16_t arr[] PROGMEM = {0xBEEF};
   EXPECT_EQ(pgm_read_word(&arr[0]), 0xBEEFu);
 }
+TEST(ProgmemTest, PGMREADWordFromUint8Unaligned) {
+  const uint8_t arr[] PROGMEM = {0xEF, 0xBE, 0xFE, 0xCA};
+  EXPECT_EQ(pgm_read_word(reinterpret_cast<const void*>(&arr[0])), 0xBEEFu);
+  EXPECT_EQ(pgm_read_word(reinterpret_cast<const void*>(&arr[1])), 0xFEBEu);
+}
 TEST(AnalogTest, AnalogReadReturnsZero) { EXPECT_EQ(analogRead(0), 0); }
 TEST(AnalogTest, AnalogWriteCompiles) { EXPECT_NO_THROW(analogWrite(0, 128)); }

--- a/test/esp32_apis_gtest.cpp
+++ b/test/esp32_apis_gtest.cpp
@@ -80,3 +80,14 @@ TEST(StringBaseTest, BinaryFormatting) { EXPECT_EQ(String(255UL, BIN), "11111111
 TEST(StringBaseTest, OctalFormatting) { EXPECT_EQ(String(8UL, OCT), "10"); }
 
 TEST(StringBaseTest, DecimalFormatting) { EXPECT_EQ(String(42UL, DEC), "42"); }
+
+TEST(ProgmemTest, PGMREADByteIsIdentity) {
+  const uint8_t arr[] PROGMEM = {0x42};
+  EXPECT_EQ(pgm_read_byte(&arr[0]), 0x42);
+}
+TEST(ProgmemTest, PGMREADWordIsIdentity) {
+  const uint16_t arr[] PROGMEM = {0xBEEF};
+  EXPECT_EQ(pgm_read_word(&arr[0]), 0xBEEFu);
+}
+TEST(AnalogTest, AnalogReadReturnsZero) { EXPECT_EQ(analogRead(0), 0); }
+TEST(AnalogTest, AnalogWriteCompiles) { EXPECT_NO_THROW(analogWrite(0, 128)); }


### PR DESCRIPTION
Closes #112

## Summary
- PROGMEM, pgm_read_byte, pgm_read_word — no-op shims for native builds
- analogRead() returns 0, analogWrite() is a no-op

## Test plan
- [ ] CI green
- [ ] 4 new tests in esp32_apis_gtest

🤖 Generated with [Claude Code](https://claude.com/claude-code)