### PR TITLE
feat: Add disconnect(bool) single-arg overload to WiFiClass

### DIFF
--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -45,6 +45,7 @@ class WiFiClass {
   void mode(wifi_mode_t m) { _mode = m; }
   wifi_mode_t getMode() const { return _mode; }
   void disconnect();
+  void disconnect(bool wifiOff) { disconnect(wifiOff, false); }
 
   // Extended API
   void disconnect(bool wifiOff, bool eraseAP);

--- a/test/wifi_gtest.cpp
+++ b/test/wifi_gtest.cpp
@@ -34,6 +34,11 @@ TEST_F(WiFiTest, DisconnectWithArgs) {
   EXPECT_EQ(WiFi.status(), WL_DISCONNECTED);
 }
 
+TEST_F(WiFiTest, DisconnectSingleArgCompiles) {
+  EXPECT_NO_THROW(WiFi.disconnect(true));
+  EXPECT_NO_THROW(WiFi.disconnect(false));
+}
+
 TEST_F(WiFiTest, RSSIReturnsMockValue) {
   EXPECT_EQ(WiFi.RSSI(), -50);
   WiFi.setRSSI(-75);


### PR DESCRIPTION
Closes #115

## Summary

Adds `disconnect(bool wifiOff)` which delegates to `disconnect(wifiOff, false)`, matching the real ESP32 WiFi API.

## Test plan
- [ ] CI green
- [ ] DisconnectSingleArgCompiles test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)