### PR TITLE
feat: Add operator==, operator!=, operator String() to IPAddress

### DIFF
--- a/src/IPAddress.h
+++ b/src/IPAddress.h
@@ -17,20 +17,27 @@ class IPAddress {
 
   uint8_t operator[](int index) const { return _address[index]; }
 
+  bool operator==(const IPAddress& other) const {
+    return _address[0] == other._address[0] && _address[1] == other._address[1] &&
+           _address[2] == other._address[2] && _address[3] == other._address[3];
+  }
+  bool operator!=(const IPAddress& other) const { return !(*this == other); }
+  operator String() const { return toString(); }
+
   String toString() const {
     String s;
     s.reserve(16);
-    s += _address[0];
+    s += String(_address[0]);
     s += ".";
-    s += _address[1];
+    s += String(_address[1]);
     s += ".";
-    s += _address[2];
+    s += String(_address[2]);
     s += ".";
-    s += _address[3];
+    s += String(_address[3]);
     return s;
   }
 
  private:
-  uint8_t *raw_address() { return _address; }
+  uint8_t* raw_address() { return _address; }
   uint8_t _address[4];
 };

--- a/test/wifi_gtest.cpp
+++ b/test/wifi_gtest.cpp
@@ -163,3 +163,24 @@ TEST(WiFiClientTest, StopDisconnects) {
   client.stop();
   EXPECT_FALSE(static_cast<bool>(client));
 }
+
+TEST(IPAddressTest, EqualityOperator) {
+  IPAddress a(192, 168, 1, 1);
+  IPAddress b(192, 168, 1, 1);
+  IPAddress c(10, 0, 0, 1);
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a == c);
+}
+
+TEST(IPAddressTest, InequalityOperator) {
+  IPAddress a(192, 168, 1, 1);
+  IPAddress b(10, 0, 0, 1);
+  EXPECT_TRUE(a != b);
+  EXPECT_FALSE(a != a);
+}
+
+TEST(IPAddressTest, StringConversion) {
+  IPAddress ip(192, 168, 1, 100);
+  String s = ip;  // implicit conversion
+  EXPECT_STREQ(s.c_str(), "192.168.1.100");
+}


### PR DESCRIPTION
Closes #114

## Summary

- operator== / operator!= for IPAddress comparison
- operator String() implicit conversion (enables println(ip) etc.)

## Test plan
- [ ] CI green
- [ ] 3 new IPAddress tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)