### PR TITLE
feat: WiFiClient inherits from Client; add WiFiClientSecure stub

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -2,11 +2,34 @@
 
 bool WiFiClient::_canConnect = true;
 
+int WiFiClient::connect(IPAddress ip, uint16_t port) { return connect(ip, port, 0) ? 1 : 0; }
+
+int WiFiClient::connect(const char *, uint16_t) {
+  _connected = _canConnect;
+  return _connected ? 1 : 0;
+}
+
 bool WiFiClient::connect(IPAddress, uint16_t, int) {
   _connected = _canConnect;
   return _connected;
 }
 
+size_t WiFiClient::write(uint8_t) { return 0; }
+
+size_t WiFiClient::write(const uint8_t *, size_t) { return 0; }
+
+int WiFiClient::available() { return 0; }
+
+int WiFiClient::read() { return -1; }
+
+int WiFiClient::read(uint8_t *, size_t) { return 0; }
+
+int WiFiClient::peek() { return -1; }
+
+void WiFiClient::flush() {}
+
 void WiFiClient::stop() { _connected = false; }
 
-WiFiClient::operator bool() const { return _connected; }
+uint8_t WiFiClient::connected() { return _connected ? 1 : 0; }
+
+WiFiClient::operator bool() { return _connected; }

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -1,12 +1,24 @@
 #pragma once
 
+#include "Client.h"
 #include "IPAddress.h"
 
-class WiFiClient {
+class WiFiClient : public Client {
  public:
-  bool connect(IPAddress ip, uint16_t port, int timeout = 0);
-  void stop();
-  operator bool() const;
+  int connect(IPAddress ip, uint16_t port) override;
+  int connect(const char *host, uint16_t port) override;
+  bool connect(IPAddress ip, uint16_t port, int timeout);
+
+  size_t write(uint8_t) override;
+  size_t write(const uint8_t *buf, size_t size) override;
+  int available() override;
+  int read() override;
+  int read(uint8_t *buf, size_t size) override;
+  int peek() override;
+  void flush() override;
+  void stop() override;
+  uint8_t connected() override;
+  operator bool() override;
 
   // Test helper — static so tests can configure before instantiation
   static void setCanConnect(bool v) { _canConnect = v; }

--- a/src/WiFiClientSecure.h
+++ b/src/WiFiClientSecure.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "WiFiClient.h"
+
+class WiFiClientSecure : public WiFiClient {
+ public:
+  void setInsecure() {}
+  void setCACert(const char *) {}
+  void setCertificate(const char *) {}
+  void setPrivateKey(const char *) {}
+};

--- a/test/wifi_gtest.cpp
+++ b/test/wifi_gtest.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
+#include "Client.h"
 #include "WiFi.h"
 #include "WiFiClient.h"
+#include "WiFiClientSecure.h"
 
 class WiFiTest : public ::testing::Test {
  protected:
@@ -149,20 +151,25 @@ TEST_F(WiFiTest, ResetRestoresDefaultMode) {
 
 // WiFiClient tests
 
-TEST(WiFiClientTest, ConnectsByDefault) {
+class WiFiClientTest : public ::testing::Test {
+ protected:
+  void SetUp() override { WiFiClient::setCanConnect(true); }
+};
+
+TEST_F(WiFiClientTest, ConnectsByDefault) {
   WiFiClient client;
   EXPECT_TRUE(client.connect(IPAddress(8, 8, 8, 8), 80));
   EXPECT_TRUE(static_cast<bool>(client));
 }
 
-TEST(WiFiClientTest, SetCanConnectFalse) {
+TEST_F(WiFiClientTest, SetCanConnectFalse) {
   WiFiClient client;
   client.setCanConnect(false);
   EXPECT_FALSE(client.connect(IPAddress(8, 8, 8, 8), 80));
   EXPECT_FALSE(static_cast<bool>(client));
 }
 
-TEST(WiFiClientTest, StopDisconnects) {
+TEST_F(WiFiClientTest, StopDisconnects) {
   WiFiClient client;
   client.connect(IPAddress(8, 8, 8, 8), 80);
   client.stop();
@@ -188,4 +195,27 @@ TEST(IPAddressTest, StringConversion) {
   IPAddress ip(192, 168, 1, 100);
   String s = ip;  // implicit conversion
   EXPECT_STREQ(s.c_str(), "192.168.1.100");
+}
+
+TEST_F(WiFiClientTest, InheritsFromClient) {
+  WiFiClient client;
+  Client *base = &client;
+  EXPECT_NE(base, nullptr);
+  EXPECT_TRUE(base->connect(IPAddress(1, 2, 3, 4), 80));
+}
+
+// WiFiClientSecure tests
+
+TEST(WiFiClientSecureTest, InheritsFromWiFiClient) {
+  WiFiClientSecure secure;
+  WiFiClient *base = &secure;
+  EXPECT_NE(base, nullptr);
+}
+
+TEST(WiFiClientSecureTest, SetInsecureCompiles) {
+  WiFiClientSecure secure;
+  secure.setInsecure();
+  secure.setCACert("cert");
+  secure.setCertificate("cert");
+  secure.setPrivateKey("key");
 }


### PR DESCRIPTION
## Summary
- `WiFiClient` now inherits from `Client` (which extends `Stream`), matching the real ESP32 Arduino IS-A hierarchy
- All `Client` pure virtuals implemented; `operator bool()` made non-const to match the abstract signature
- Added `WiFiClientSecure` stub inheriting from `WiFiClient` with no-op TLS config methods
- Tests verify IS-A relationships and `setCanConnect` behaviour is preserved

Closes #122
Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)