### PR TITLE
feat: fix Update API — bridge header, constants, command param, getError, writeStream

### DIFF
--- a/src/Update.h
+++ b/src/Update.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "Updater.h"

--- a/src/Updater.h
+++ b/src/Updater.h
@@ -2,10 +2,20 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "Stream.h"
+
+#ifndef U_FLASH
+#define U_FLASH 0
+#endif
+#ifndef U_SPIFFS
+#define U_SPIFFS 100
+#endif
+
 class UpdateClass {
  public:
-  bool begin(size_t size = 0) {
+  bool begin(size_t size = 0, int command = U_FLASH) {
     (void)size;
+    (void)command;
     return false;
   }
   bool end(bool evenIfRemaining = false) {
@@ -16,13 +26,14 @@ class UpdateClass {
     (void)data;
     return 0;
   }
-  size_t writeStream(void* stream) {
+  size_t writeStream(Stream& stream) {
     (void)stream;
     return 0;
   }
   bool isRunning() { return false; }
   bool isFinished() { return false; }
   bool hasError() { return false; }
+  uint8_t getError() { return 0; }
   void clearError() {}
   const char* errorString() { return ""; }
   size_t size() { return 0; }

--- a/test/updater_gtest.cpp
+++ b/test/updater_gtest.cpp
@@ -30,3 +30,15 @@ TEST(UpdaterTest, GlobalUpdateInstanceIsAccessible) {
   UpdateClass* ptr = &Update;
   EXPECT_NE(ptr, nullptr);
 }
+
+TEST(UpdaterTest, UFlashAndUSpiffsDefined) {
+  EXPECT_EQ(U_FLASH, 0);
+  EXPECT_EQ(U_SPIFFS, 100);
+}
+
+TEST(UpdaterTest, BeginWithCommand) {
+  EXPECT_FALSE(Update.begin(1024, U_FLASH));
+  EXPECT_FALSE(Update.begin(1024, U_SPIFFS));
+}
+
+TEST(UpdaterTest, GetErrorReturnsZero) { EXPECT_EQ(Update.getError(), static_cast<uint8_t>(0)); }

--- a/test/updater_gtest.cpp
+++ b/test/updater_gtest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "Updater.h"
+#include "Update.h"
 
 TEST(UpdaterTest, BeginDefaultReturnsFalse) { EXPECT_FALSE(Update.begin()); }
 


### PR DESCRIPTION
## Summary
- Add `Update.h` bridge header so `#include <Update.h>` works (matches real ESP32 include path)
- Define `U_FLASH=0` and `U_SPIFFS=100` constants
- `begin()` now accepts optional `int command` parameter (default `U_FLASH`)
- `writeStream()` now takes `Stream&` instead of `void*` so `WiFiClient` objects can be passed
- Add `getError()` returning `uint8_t`

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)