### PR TITLE
feat: add xQueueSendToFront, xQueueSendToBack, xQueuePeek, taskYIELD

### DIFF
--- a/src/freertos/queue/queue.cpp
+++ b/src/freertos/queue/queue.cpp
@@ -76,4 +76,45 @@ UBaseType_t uxQueueMessagesWaiting(QueueHandle_t xQueue) {
   return static_cast<UBaseType_t>(q->q.size());
 }
 
+BaseType_t xQueueSendToBack(
+    QueueHandle_t xQueue, const void* pvItemToQueue, TickType_t xTicksToWait) {
+  return xQueueSend(xQueue, pvItemToQueue, xTicksToWait);
+}
+
+BaseType_t xQueueSendToFront(
+    QueueHandle_t xQueue, const void* pvItemToQueue, TickType_t xTicksToWait) {
+  auto* q = xQueue;
+  if (!q || !pvItemToQueue) return pdFALSE;
+  std::unique_lock<std::mutex> lk(q->mtx);
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(xTicksToWait);
+  while (q->q.size() >= q->capacity) {
+    if (xTicksToWait == 0) return pdFALSE;
+    if (q->cv_not_full.wait_until(lk, deadline) == std::cv_status::timeout) {
+      if (q->q.size() >= q->capacity) return pdFALSE;
+      break;
+    }
+  }
+  std::vector<uint8_t> item(q->item_size);
+  std::memcpy(item.data(), pvItemToQueue, q->item_size);
+  q->q.push_front(std::move(item));
+  q->cv_not_empty.notify_one();
+  return pdTRUE;
+}
+
+BaseType_t xQueuePeek(QueueHandle_t xQueue, void* pvBuffer, TickType_t xTicksToWait) {
+  auto* q = xQueue;
+  if (!q || !pvBuffer) return pdFALSE;
+  std::unique_lock<std::mutex> lk(q->mtx);
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(xTicksToWait);
+  while (q->q.empty()) {
+    if (xTicksToWait == 0) return pdFALSE;
+    if (q->cv_not_empty.wait_until(lk, deadline) == std::cv_status::timeout) {
+      if (q->q.empty()) return pdFALSE;
+      break;
+    }
+  }
+  std::memcpy(pvBuffer, q->q.front().data(), q->item_size);
+  return pdTRUE;
+}
+
 }  // extern "C"

--- a/src/freertos/queue/queue.h
+++ b/src/freertos/queue/queue.h
@@ -18,6 +18,12 @@ BaseType_t xQueueReceive(QueueHandle_t xQueue, void* pvBuffer, TickType_t xTicks
 
 UBaseType_t uxQueueMessagesWaiting(QueueHandle_t xQueue);
 
+BaseType_t xQueueSendToFront(
+    QueueHandle_t xQueue, const void* pvItemToQueue, TickType_t xTicksToWait);
+BaseType_t xQueueSendToBack(
+    QueueHandle_t xQueue, const void* pvItemToQueue, TickType_t xTicksToWait);
+BaseType_t xQueuePeek(QueueHandle_t xQueue, void* pvBuffer, TickType_t xTicksToWait);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/freertos/task/task.h
+++ b/src/freertos/task/task.h
@@ -18,6 +18,10 @@ typedef struct TaskControlBlock* TaskHandle_t;
 #define tskIDLE_PRIORITY 0
 #endif
 
+#ifndef taskYIELD
+#define taskYIELD() ((void)0)
+#endif
+
 // Task notification actions
 typedef enum {
   eNoAction,

--- a/test/queue_gtest.cpp
+++ b/test/queue_gtest.cpp
@@ -25,3 +25,58 @@ TEST(QueueTest, BasicSendReceive) {
 
   vQueueDelete(q);
 }
+
+TEST(QueueTest, SendToBackWorks) {
+  QueueHandle_t q = xQueueCreate(2, sizeof(uint32_t));
+  ASSERT_NE(q, nullptr);
+
+  uint32_t v = 0xDEADBEEF;
+  EXPECT_EQ(xQueueSendToBack(q, &v, 0), pdTRUE);
+
+  uint32_t r = 0;
+  EXPECT_EQ(xQueueReceive(q, &r, 0), pdTRUE);
+  EXPECT_EQ(r, v);
+
+  vQueueDelete(q);
+}
+
+TEST(QueueTest, SendToFrontWorks) {
+  QueueHandle_t q = xQueueCreate(3, sizeof(uint32_t));
+  ASSERT_NE(q, nullptr);
+
+  uint32_t v1 = 0x11111111;
+  uint32_t v2 = 0x22222222;
+  uint32_t vf = 0xFFFFFFFF;
+
+  EXPECT_EQ(xQueueSendToBack(q, &v1, 0), pdTRUE);
+  EXPECT_EQ(xQueueSendToBack(q, &v2, 0), pdTRUE);
+  EXPECT_EQ(xQueueSendToFront(q, &vf, 0), pdTRUE);
+
+  uint32_t r0 = 0, r1 = 0, r2 = 0;
+  EXPECT_EQ(xQueueReceive(q, &r0, 0), pdTRUE);
+  EXPECT_EQ(xQueueReceive(q, &r1, 0), pdTRUE);
+  EXPECT_EQ(xQueueReceive(q, &r2, 0), pdTRUE);
+  EXPECT_EQ(r0, vf);
+  EXPECT_EQ(r1, v1);
+  EXPECT_EQ(r2, v2);
+
+  vQueueDelete(q);
+}
+
+TEST(QueueTest, PeekDoesNotRemove) {
+  QueueHandle_t q = xQueueCreate(2, sizeof(uint32_t));
+  ASSERT_NE(q, nullptr);
+
+  uint32_t v = 0xCAFEBABE;
+  EXPECT_EQ(xQueueSend(q, &v, 0), pdTRUE);
+
+  uint32_t peeked = 0;
+  EXPECT_EQ(xQueuePeek(q, &peeked, 0), pdTRUE);
+  EXPECT_EQ(peeked, v);
+
+  uint32_t received = 0;
+  EXPECT_EQ(xQueueReceive(q, &received, 0), pdTRUE);
+  EXPECT_EQ(received, v);
+
+  vQueueDelete(q);
+}

--- a/test/task_gtest.cpp
+++ b/test/task_gtest.cpp
@@ -19,3 +19,5 @@ TEST(TaskTest, TickAndCreate) {
   vTaskDelay(pdMS_TO_TICKS(80));
   vTaskEndScheduler();
 }
+
+TEST(TaskTest, TaskYieldCompiles) { taskYIELD(); }


### PR DESCRIPTION
## Summary
- `xQueueSendToFront` pushes item to the front of the queue (highest priority)
- `xQueueSendToBack` is an explicit alias for `xQueueSend` (back of queue)
- `xQueuePeek` reads the front item without removing it
- `taskYIELD()` defined as `((void)0)` no-op macro

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)