### PR TITLE
feat: add String::clear() and AlarmClass::write(id, seconds)

### DIFF
--- a/src/TimeAlarms.h
+++ b/src/TimeAlarms.h
@@ -81,8 +81,9 @@ class AlarmClass {
 
   void write(AlarmID_t id, time_t seconds) {
     if (id >= MAX_ALARMS) return;
-    _alarms[id].intervalMs = static_cast<unsigned long>(seconds) * 1000;
-    _alarms[id].nextFire = std::chrono::steady_clock::now() + std::chrono::seconds(seconds);
+    const time_t clampedSeconds = (seconds > 0) ? seconds : 0;
+    _alarms[id].intervalMs = static_cast<unsigned long>(clampedSeconds) * 1000;
+    _alarms[id].nextFire = std::chrono::steady_clock::now() + std::chrono::seconds(clampedSeconds);
   }
 
   void writeNextTrigger(AlarmID_t id, time_t timestamp) {

--- a/src/TimeAlarms.h
+++ b/src/TimeAlarms.h
@@ -79,6 +79,12 @@ class AlarmClass {
     return static_cast<time_t>(std::time(nullptr) + (secs > 0 ? secs : 0));
   }
 
+  void write(AlarmID_t id, time_t seconds) {
+    if (id >= MAX_ALARMS) return;
+    _alarms[id].intervalMs = static_cast<unsigned long>(seconds) * 1000;
+    _alarms[id].nextFire = std::chrono::steady_clock::now() + std::chrono::seconds(seconds);
+  }
+
   void writeNextTrigger(AlarmID_t id, time_t timestamp) {
     if (id >= MAX_ALARMS) return;
     const time_t nowTime = std::time(nullptr);

--- a/src/WString.h
+++ b/src/WString.h
@@ -92,6 +92,7 @@ class String {
 
   const char* c_str() const { return _data.c_str(); }
   size_t length() const { return _data.length(); }
+  void clear() { _data.clear(); }
 
   char charAt(int index) const {
     if (index >= 0 && static_cast<size_t>(index) < _data.size()) { return _data[index]; }

--- a/src/WString.h
+++ b/src/WString.h
@@ -92,7 +92,10 @@ class String {
 
   const char* c_str() const { return _data.c_str(); }
   size_t length() const { return _data.length(); }
-  void clear() { _data.clear(); }
+  void clear() {
+    _data.clear();
+    _readPos = 0;
+  }
 
   char charAt(int index) const {
     if (index >= 0 && static_cast<size_t>(index) < _data.size()) { return _data[index]; }

--- a/test/string_read_gtest.cpp
+++ b/test/string_read_gtest.cpp
@@ -46,3 +46,16 @@ TEST(StringReadTest, ReadWorksWithHighBytes) {
   EXPECT_EQ(s.read(), 0xC0);
   EXPECT_EQ(s.read(), 0xFF);
 }
+
+TEST(StringClearTest, ClearEmptiesString) {
+  String s("hello");
+  s.clear();
+  EXPECT_EQ(s.length(), 0u);
+  EXPECT_STREQ(s.c_str(), "");
+}
+
+TEST(StringClearTest, ClearOnEmptyStringIsNoOp) {
+  String s;
+  EXPECT_NO_THROW(s.clear());
+  EXPECT_EQ(s.length(), 0u);
+}

--- a/test/time_alarms_gtest.cpp
+++ b/test/time_alarms_gtest.cpp
@@ -157,3 +157,18 @@ TEST(TimeAlarmsTest, WriteNextTriggerOutOfRangeIdDoesNotCrash) {
   Alarm.reset();
   EXPECT_NO_THROW(Alarm.writeNextTrigger(dtINVALID_ALARM_ID, std::time(nullptr) + 10));
 }
+
+TEST(TimeAlarmsTest, WriteUpdatesIntervalAndReschedulesAlarm) {
+  Alarm.reset();
+  AlarmID_t id = Alarm.timerRepeat(100, nullptr);
+  Alarm.write(id, 30);
+  time_t next = Alarm.getNextTrigger(id);
+  time_t now = std::time(nullptr);
+  EXPECT_GE(next, now + 28);
+  EXPECT_LE(next, now + 32);
+}
+
+TEST(TimeAlarmsTest, WriteOutOfRangeIdDoesNotCrash) {
+  Alarm.reset();
+  EXPECT_NO_THROW(Alarm.write(dtINVALID_ALARM_ID, 10));
+}

--- a/test/time_alarms_gtest.cpp
+++ b/test/time_alarms_gtest.cpp
@@ -162,8 +162,8 @@ TEST(TimeAlarmsTest, WriteUpdatesIntervalAndReschedulesAlarm) {
   Alarm.reset();
   AlarmID_t id = Alarm.timerRepeat(100, nullptr);
   Alarm.write(id, 30);
-  time_t next = Alarm.getNextTrigger(id);
   time_t now = std::time(nullptr);
+  time_t next = Alarm.getNextTrigger(id);
   EXPECT_GE(next, now + 28);
   EXPECT_LE(next, now + 32);
 }


### PR DESCRIPTION
## Summary
- `String::clear()` delegates to the underlying `std::string::clear()` — empties the string in place
- `AlarmClass::write(id, seconds)` updates the alarm's interval and reschedules its next fire time, matching the real TimeAlarms library API

Closes #129
Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)