### PR TITLE
feat: add String::equals(), equalsIgnoreCase(), and write() methods

### DIFF
--- a/src/WString.h
+++ b/src/WString.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 #include <type_traits>
@@ -89,6 +91,19 @@ class String {
 
   bool operator==(const char* rhs) const { return _data == rhs; }
   bool operator!=(const char* rhs) const { return _data != rhs; }
+
+  bool equals(const String& rhs) const { return _data == rhs._data; }
+  bool equals(const char* rhs) const { return _data == rhs; }
+
+  bool equalsIgnoreCase(const String& rhs) const {
+    if (_data.size() != rhs._data.size()) return false;
+    for (size_t i = 0; i < _data.size(); i++) {
+      if (tolower(static_cast<unsigned char>(_data[i])) !=
+          tolower(static_cast<unsigned char>(rhs._data[i])))
+        return false;
+    }
+    return true;
+  }
 
   const char* c_str() const { return _data.c_str(); }
   size_t length() const { return _data.length(); }
@@ -232,6 +247,16 @@ class String {
   }
 
   bool isEmpty() const { return _data.empty(); }
+
+  size_t write(uint8_t c) {
+    _data += static_cast<char>(c);
+    return 1;
+  }
+
+  size_t write(const uint8_t* buf, size_t size) {
+    _data.append(reinterpret_cast<const char*>(buf), size);
+    return size;
+  }
 
   // Stream-like read interface (used by ArduinoJson Reader<String>)
   int read() const {

--- a/test/string_read_gtest.cpp
+++ b/test/string_read_gtest.cpp
@@ -59,3 +59,48 @@ TEST(StringClearTest, ClearOnEmptyStringIsNoOp) {
   EXPECT_NO_THROW(s.clear());
   EXPECT_EQ(s.length(), 0u);
 }
+
+TEST(StringEqualsTest, EqualsString) {
+  String a("hello");
+  String b("hello");
+  String c("world");
+  EXPECT_TRUE(a.equals(b));
+  EXPECT_FALSE(a.equals(c));
+}
+
+TEST(StringEqualsTest, EqualsCStr) {
+  String a("hello");
+  EXPECT_TRUE(a.equals("hello"));
+  EXPECT_FALSE(a.equals("world"));
+}
+
+TEST(StringEqualsTest, EqualsIgnoreCaseMatch) {
+  String a("Hello");
+  String b("HELLO");
+  EXPECT_TRUE(a.equalsIgnoreCase(b));
+}
+
+TEST(StringEqualsTest, EqualsIgnoreCaseMismatch) {
+  String a("Hello");
+  String b("World");
+  EXPECT_FALSE(a.equalsIgnoreCase(b));
+}
+
+TEST(StringEqualsTest, EqualsIgnoreCaseDifferentLength) {
+  String a("Hello");
+  String b("Hello!");
+  EXPECT_FALSE(a.equalsIgnoreCase(b));
+}
+
+TEST(StringWriteTest, WriteByteAppendsChar) {
+  String s;
+  EXPECT_EQ(s.write(static_cast<uint8_t>('A')), 1u);
+  EXPECT_STREQ(s.c_str(), "A");
+}
+
+TEST(StringWriteTest, WriteBufferAppendsBytes) {
+  String s;
+  const uint8_t buf[] = {'h', 'i'};
+  EXPECT_EQ(s.write(buf, 2), 2u);
+  EXPECT_STREQ(s.c_str(), "hi");
+}


### PR DESCRIPTION
## Summary
- `equals(String)` / `equals(const char*)` — named equality methods matching Arduino API
- `equalsIgnoreCase(String)` — case-insensitive comparison
- `write(uint8_t)` / `write(const uint8_t*, size_t)` — output methods enabling ArduinoJson serialization into `String`

Closes #134
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)