### PR TITLE
feat: add WiFiClass soft-AP methods, enableAP/STA, credential helpers, no-arg begin()

### DIFF
--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -43,6 +43,24 @@ class WiFiClass {
   String macAddress();
   void macAddress(uint8_t* mac);
   bool begin(const char* ssid, const char* password);
+  // No-arg begin — reconnect using saved credentials (stub: returns _beginConnects)
+  bool begin() { return _beginConnects; }
+
+  // Soft AP
+  bool softAP(const char*, const char* = nullptr, int = 1, int = 0, int = 4) { return true; }
+  bool softAPConfig(IPAddress, IPAddress, IPAddress) { return true; }
+  bool softAPdisconnect(bool = false) { return true; }
+  uint8_t softAPgetStationNum() { return 0; }
+  IPAddress softAPIP() { return IPAddress(192, 168, 3, 3); }
+
+  // AP/STA enable
+  bool enableAP(bool) { return true; }
+  bool enableSTA(bool) { return true; }
+
+  // Credential/reconnect helpers
+  String psk() { return String(""); }
+  bool getAutoConnect() { return true; }
+  bool getAutoReconnect() { return true; }
   void mode(wifi_mode_t m) { _mode = m; }
   wifi_mode_t getMode() const { return _mode; }
   void disconnect();

--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -44,7 +44,14 @@ class WiFiClass {
   void macAddress(uint8_t* mac);
   bool begin(const char* ssid, const char* password);
   // No-arg begin — reconnect using saved credentials (stub: returns _beginConnects)
-  bool begin() { return _beginConnects; }
+  bool begin() {
+    if (_beginConnects) {
+      _status = WL_CONNECTED;
+    } else {
+      _status = WL_CONNECT_FAILED;
+    }
+    return _beginConnects;
+  }
 
   // Soft AP
   bool softAP(const char*, const char* = nullptr, int = 1, int = 0, int = 4) { return true; }

--- a/test/wifi_gtest.cpp
+++ b/test/wifi_gtest.cpp
@@ -225,3 +225,37 @@ TEST(WiFiClientSecureTest, SetInsecureCompiles) {
   secure.setCertificate("cert");
   secure.setPrivateKey("key");
 }
+
+TEST_F(WiFiTest, NoArgBeginReturnsBeginConnects) {
+  EXPECT_TRUE(WiFi.begin());
+  WiFi.setBeginConnects(false);
+  EXPECT_FALSE(WiFi.begin());
+}
+
+TEST(WiFiSoftAPTest, SoftAPReturnsTrue) {
+  EXPECT_TRUE(WiFi.softAP("TestAP"));
+  EXPECT_TRUE(WiFi.softAP("TestAP", "pass123"));
+}
+
+TEST(WiFiSoftAPTest, SoftAPConfigReturnsTrue) {
+  EXPECT_TRUE(WiFi.softAPConfig(
+      IPAddress(192, 168, 4, 1), IPAddress(192, 168, 4, 1), IPAddress(255, 255, 255, 0)));
+}
+
+TEST(WiFiSoftAPTest, SoftAPDisconnectReturnsTrue) { EXPECT_TRUE(WiFi.softAPdisconnect()); }
+
+TEST(WiFiSoftAPTest, SoftAPgetStationNumReturnsZero) { EXPECT_EQ(WiFi.softAPgetStationNum(), 0u); }
+
+TEST(WiFiSoftAPTest, SoftAPIPreturnsDefaultIP) {
+  IPAddress ip = WiFi.softAPIP();
+  EXPECT_EQ(ip[0], 192);
+  EXPECT_EQ(ip[1], 168);
+  EXPECT_EQ(ip[2], 3);
+  EXPECT_EQ(ip[3], 3);
+}
+
+TEST(WiFiSoftAPTest, EnableAPReturnsTrue) { EXPECT_TRUE(WiFi.enableAP(true)); }
+TEST(WiFiSoftAPTest, EnableSTAReturnsTrue) { EXPECT_TRUE(WiFi.enableSTA(true)); }
+TEST(WiFiSoftAPTest, PskReturnsEmptyString) { EXPECT_STREQ(WiFi.psk().c_str(), ""); }
+TEST(WiFiSoftAPTest, GetAutoConnectReturnsTrue) { EXPECT_TRUE(WiFi.getAutoConnect()); }
+TEST(WiFiSoftAPTest, GetAutoReconnectReturnsTrue) { EXPECT_TRUE(WiFi.getAutoReconnect()); }

--- a/test/wifi_gtest.cpp
+++ b/test/wifi_gtest.cpp
@@ -246,7 +246,7 @@ TEST(WiFiSoftAPTest, SoftAPDisconnectReturnsTrue) { EXPECT_TRUE(WiFi.softAPdisco
 
 TEST(WiFiSoftAPTest, SoftAPgetStationNumReturnsZero) { EXPECT_EQ(WiFi.softAPgetStationNum(), 0u); }
 
-TEST(WiFiSoftAPTest, SoftAPIPreturnsDefaultIP) {
+TEST(WiFiSoftAPTest, SoftAPIPReturnsDefaultIP) {
   IPAddress ip = WiFi.softAPIP();
   EXPECT_EQ(ip[0], 192);
   EXPECT_EQ(ip[1], 168);


### PR DESCRIPTION
## Summary
- `softAP()`, `softAPConfig()`, `softAPdisconnect()`, `softAPgetStationNum()`, `softAPIP()` — soft access point stubs
- `enableAP(bool)` / `enableSTA(bool)` — mode enable stubs
- `psk()`, `getAutoConnect()`, `getAutoReconnect()` — credential/reconnect helpers
- `begin()` — no-arg overload reconnecting with saved credentials (returns `_beginConnects`)

All are no-op stubs returning safe defaults since native builds don't manage real WiFi hardware.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)