### PR TITLE
feat: add wifi_config_t, esp_wifi_get/set_config, and pdTICKS_TO_MS

### DIFF
--- a/src/esp_wifi.h
+++ b/src/esp_wifi.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 
 #ifndef ESP_OK
 #define ESP_OK 0
@@ -22,6 +23,29 @@ typedef enum {
 } wifi_second_chan_t;
 
 typedef int esp_err_t;
+
+struct wifi_sta_config_t {
+  uint8_t ssid[32];
+  uint8_t password[64];
+};
+
+struct wifi_ap_config_t {
+  uint8_t ssid[32];
+};
+
+union wifi_config_t {
+  wifi_sta_config_t sta;
+  wifi_ap_config_t ap;
+};
+
+inline esp_err_t esp_wifi_get_config(wifi_interface_t /*ifx*/, wifi_config_t* cfg) {
+  if (cfg) std::memset(cfg, 0, sizeof(wifi_config_t));
+  return ESP_OK;
+}
+
+inline esp_err_t esp_wifi_set_config(wifi_interface_t /*ifx*/, wifi_config_t* /*cfg*/) {
+  return ESP_OK;
+}
 
 inline esp_err_t esp_wifi_get_mac(wifi_interface_t ifx, uint8_t* mac) {
   (void)ifx;

--- a/src/freertos/projdefs.h
+++ b/src/freertos/projdefs.h
@@ -23,6 +23,7 @@ typedef uint32_t portSTACK_TYPE;
 #endif
 
 #define pdMS_TO_TICKS(x) ((TickType_t)((x) / portTICK_PERIOD_MS))
+#define pdTICKS_TO_MS(x) ((uint32_t)((x) * portTICK_PERIOD_MS))
 
 #ifndef portMAX_DELAY
 #define portMAX_DELAY ((TickType_t)0xffffffffUL)

--- a/test/esp32_core_mocks_gtest.cpp
+++ b/test/esp32_core_mocks_gtest.cpp
@@ -28,6 +28,24 @@ TEST(EspWifiTest, GetChannelReturnsOkAndSetsPrimaryAndSecond) {
   EXPECT_EQ(second, WIFI_SECOND_CHAN_NONE);
 }
 
+// --- esp_wifi_get_config / esp_wifi_set_config ---
+
+TEST(EspWifiConfigTest, GetConfigReturnsOkAndZeroesBuffer) {
+  wifi_config_t cfg;
+  cfg.sta.ssid[0] = 0xFF;
+  EXPECT_EQ(esp_wifi_get_config(WIFI_IF_STA, &cfg), ESP_OK);
+  EXPECT_EQ(cfg.sta.ssid[0], 0);
+}
+
+TEST(EspWifiConfigTest, SetConfigReturnsOk) {
+  wifi_config_t cfg{};
+  EXPECT_EQ(esp_wifi_set_config(WIFI_IF_STA, &cfg), ESP_OK);
+}
+
+TEST(EspWifiConfigTest, GetConfigNullptrDoesNotCrash) {
+  EXPECT_EQ(esp_wifi_get_config(WIFI_IF_STA, nullptr), ESP_OK);
+}
+
 // --- WIFI_IF_STA / WIFI_IF_AP ---
 
 TEST(EspWifiTest, InterfaceConstants) {

--- a/test/queue_gtest.cpp
+++ b/test/queue_gtest.cpp
@@ -81,7 +81,7 @@ TEST(QueueTest, PeekDoesNotRemove) {
   vQueueDelete(q);
 }
 
-TEST(ProjdefsTest, TicksToMsRoundtrips) {
-  EXPECT_EQ(pdTICKS_TO_MS(1000), 1000u);
+TEST(ProjdefsTest, TicksToMsRespectsPortTickPeriod) {
+  EXPECT_EQ(pdTICKS_TO_MS(1000), 1000u * portTICK_PERIOD_MS);
   EXPECT_EQ(pdTICKS_TO_MS(0), 0u);
 }

--- a/test/queue_gtest.cpp
+++ b/test/queue_gtest.cpp
@@ -80,3 +80,8 @@ TEST(QueueTest, PeekDoesNotRemove) {
 
   vQueueDelete(q);
 }
+
+TEST(ProjdefsTest, TicksToMsRoundtrips) {
+  EXPECT_EQ(pdTICKS_TO_MS(1000), 1000u);
+  EXPECT_EQ(pdTICKS_TO_MS(0), 0u);
+}


### PR DESCRIPTION
## Summary
- `wifi_sta_config_t`, `wifi_ap_config_t`, `wifi_config_t` union — ESP-IDF WiFi config structs
- `esp_wifi_get_config()` — zeroes caller buffer and returns `ESP_OK`
- `esp_wifi_set_config()` — no-op stub returning `ESP_OK`
- `pdTICKS_TO_MS(x)` — inverse of `pdMS_TO_TICKS`, converts tick count to milliseconds

Closes #136
Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)