### PR TITLE
fix: replace std::sprintf with std::snprintf in dtostrf

### DIFF
--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -216,7 +216,10 @@ inline bool isAlpha(char c) { return isalpha(static_cast<unsigned char>(c)); }
 inline bool isAlphaNumeric(char c) { return isalnum(static_cast<unsigned char>(c)); }
 
 inline char* dtostrf(double val, signed char width, unsigned char prec, char* buf) {
-  std::snprintf(buf, 64, "%*.*f", static_cast<int>(width), static_cast<int>(prec), val);
+  // 64 bytes matches the Arduino reference implementation and is sufficient
+  // for any double with reasonable width/precision values.
+  constexpr size_t kBufMax = 64;
+  std::snprintf(buf, kBufMax, "%*.*f", static_cast<int>(width), static_cast<int>(prec), val);
   return buf;
 }
 

--- a/src/Arduino.h
+++ b/src/Arduino.h
@@ -216,7 +216,7 @@ inline bool isAlpha(char c) { return isalpha(static_cast<unsigned char>(c)); }
 inline bool isAlphaNumeric(char c) { return isalnum(static_cast<unsigned char>(c)); }
 
 inline char* dtostrf(double val, signed char width, unsigned char prec, char* buf) {
-  std::sprintf(buf, "%*.*f", static_cast<int>(width), static_cast<int>(prec), val);
+  std::snprintf(buf, 64, "%*.*f", static_cast<int>(width), static_cast<int>(prec), val);
   return buf;
 }
 


### PR DESCRIPTION
## Summary
- `std::sprintf` in `dtostrf` (Arduino.h) is deprecated on macOS/clang, producing `-Wdeprecated-declarations` on every TU that includes `Arduino.h`
- Switch to `std::snprintf(buf, 64, ...)` — 64 bytes matches the Arduino reference implementation and is sufficient for any double with reasonable width/precision

## Test plan
- [x] Existing `DtostrfTest.BasicConversion` and `DtostrfTest.NegativeValue` pass unchanged
- [x] Full suite passes (26/26)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)