### PR TITLE
feat: add File::read(uint8_t*, size_t) bulk-read overload

### DIFF
--- a/src/SPIFFS.cpp
+++ b/src/SPIFFS.cpp
@@ -58,6 +58,15 @@ int File::read() {
   return static_cast<uint8_t>((*_contentPtr)[_readPos++]);
 }
 
+size_t File::read(uint8_t* buf, size_t size) {
+  if (!_contentPtr || !buf) return 0;
+  size_t available = _contentPtr->size() - _readPos;
+  size_t n = size < available ? size : available;
+  std::memcpy(buf, _contentPtr->data() + _readPos, n);
+  _readPos += n;
+  return n;
+}
+
 int File::peek() {
   if (!_contentPtr || _readPos >= _contentPtr->size()) return -1;
   return static_cast<uint8_t>((*_contentPtr)[_readPos]);

--- a/src/SPIFFS.cpp
+++ b/src/SPIFFS.cpp
@@ -59,7 +59,7 @@ int File::read() {
 }
 
 size_t File::read(uint8_t* buf, size_t size) {
-  if (!_contentPtr || !buf) return 0;
+  if (!_contentPtr || !buf || _readPos >= _contentPtr->size()) return 0;
   size_t available = _contentPtr->size() - _readPos;
   size_t n = size < available ? size : available;
   std::memcpy(buf, _contentPtr->data() + _readPos, n);

--- a/src/SPIFFS.h
+++ b/src/SPIFFS.h
@@ -25,6 +25,7 @@ class File {
   size_t print(const String& str);
   size_t println(const String& str);
   int read();
+  size_t read(uint8_t* buf, size_t size);
   int peek();
   int available();
   File openNextFile();

--- a/test/spiffs_gtest.cpp
+++ b/test/spiffs_gtest.cpp
@@ -258,3 +258,52 @@ TEST_F(SPIFFSTest, FMacroCompilesAndPassesThrough) {
   const __FlashStringHelper* fstr = F("world");
   EXPECT_STREQ(reinterpret_cast<const char*>(fstr), "world");
 }
+
+// --- File::read(uint8_t*, size_t) ---
+
+TEST_F(SPIFFSTest, BulkReadReadsExactBytes) {
+  SPIFFS.addFile("/bin.dat", "ABCDE");
+  File f = SPIFFS.open("/bin.dat", FILE_READ);
+  uint8_t buf[3] = {};
+  EXPECT_EQ(f.read(buf, 3), 3u);
+  EXPECT_EQ(buf[0], 'A');
+  EXPECT_EQ(buf[1], 'B');
+  EXPECT_EQ(buf[2], 'C');
+  EXPECT_EQ(f.available(), 2);
+}
+
+TEST_F(SPIFFSTest, BulkReadAdvancesPosition) {
+  SPIFFS.addFile("/seq.dat", "12345");
+  File f = SPIFFS.open("/seq.dat", FILE_READ);
+  uint8_t first[2] = {};
+  uint8_t second[2] = {};
+  f.read(first, 2);
+  f.read(second, 2);
+  EXPECT_EQ(first[0], '1');
+  EXPECT_EQ(first[1], '2');
+  EXPECT_EQ(second[0], '3');
+  EXPECT_EQ(second[1], '4');
+}
+
+TEST_F(SPIFFSTest, BulkReadClampsAtEof) {
+  SPIFFS.addFile("/short.dat", "AB");
+  File f = SPIFFS.open("/short.dat", FILE_READ);
+  uint8_t buf[10] = {};
+  EXPECT_EQ(f.read(buf, 10), 2u);
+  EXPECT_EQ(buf[0], 'A');
+  EXPECT_EQ(buf[1], 'B');
+  EXPECT_EQ(f.available(), 0);
+}
+
+TEST_F(SPIFFSTest, BulkReadAtEofReturnsZero) {
+  SPIFFS.addFile("/empty.dat", "");
+  File f = SPIFFS.open("/empty.dat", FILE_READ);
+  uint8_t buf[4] = {};
+  EXPECT_EQ(f.read(buf, 4), 0u);
+}
+
+TEST_F(SPIFFSTest, BulkReadNullBufReturnsZero) {
+  SPIFFS.addFile("/null.dat", "data");
+  File f = SPIFFS.open("/null.dat", FILE_READ);
+  EXPECT_EQ(f.read(nullptr, 4), 0u);
+}


### PR DESCRIPTION
## Summary
- `File` in `SPIFFS.h` only had the single-byte `read()` — the bulk-read overload used widely in firmware was missing, causing compile failures in native builds
- Add `size_t read(uint8_t* buf, size_t size)` declaration to `SPIFFS.h` and implementation to `SPIFFS.cpp`: reads up to `size` bytes, advances `_readPos`, returns bytes copied

## Test plan
- [x] `BulkReadReadsExactBytes` — reads correct bytes, leaves correct `available()`
- [x] `BulkReadAdvancesPosition` — two sequential reads advance position correctly
- [x] `BulkReadClampsAtEof` — requesting more bytes than available returns actual count
- [x] `BulkReadAtEofReturnsZero` — empty file returns 0
- [x] `BulkReadNullBufReturnsZero` — null buffer guard
- [x] Full suite passes (26/26)

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)