### PR TITLE
feat: make UpdateClass configurable for OTA flow testing

### DIFF
--- a/.github/workflows/create-rc.yml
+++ b/.github/workflows/create-rc.yml
@@ -33,6 +33,7 @@ jobs:
           version: ${{ inputs.version }}
           base-branch: master
           bump-command: |
-            sed -i "s/project(ArduinoNativeMocks VERSION [^ ]*/project(ArduinoNativeMocks VERSION $VERSION/" CMakeLists.txt
+            NUMERIC_VERSION=$(echo "$VERSION" | sed 's/-.*//')
+            sed -i "s/project(ArduinoNativeMocks VERSION [^ ]*/project(ArduinoNativeMocks VERSION $NUMERIC_VERSION/" CMakeLists.txt
             sed -i "s/set(PROJECT_VERSION_SUFIX \"[^\"]*\")/set(PROJECT_VERSION_SUFIX \"-rc.1\")/" CMakeLists.txt
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(ArduinoNativeMocks VERSION 0.4.0-rc.1 LANGUAGES C CXX)
+project(ArduinoNativeMocks VERSION 0.4.0 LANGUAGES C CXX)
 
 set(PROJECT_VERSION_SUFIX "-rc.1")
 set(CMAKE_PROJECT_VERSION "${PROJECT_VERSION}${PROJECT_VERSION_SUFIX}")

--- a/src/Updater.cpp
+++ b/src/Updater.cpp
@@ -1,2 +1,28 @@
 #include "Updater.h"
+
+bool UpdateClass::_beginResult = false;
+size_t UpdateClass::_writeResult = 0;
+uint8_t UpdateClass::_error = 0;
+int UpdateClass::_endCallCount = 0;
+bool UpdateClass::_lastEndArg = false;
+
+bool UpdateClass::begin(size_t size, int command) {
+  (void)size;
+  (void)command;
+  if (!_beginResult)
+    _error = 1;
+  return _beginResult;
+}
+
+bool UpdateClass::end(bool evenIfRemaining) {
+  _endCallCount++;
+  _lastEndArg = evenIfRemaining;
+  return true;
+}
+
+size_t UpdateClass::writeStream(Stream& stream) {
+  (void)stream;
+  return _writeResult;
+}
+
 UpdateClass Update;

--- a/src/Updater.cpp
+++ b/src/Updater.cpp
@@ -9,8 +9,7 @@ bool UpdateClass::_lastEndArg = false;
 bool UpdateClass::begin(size_t size, int command) {
   (void)size;
   (void)command;
-  if (!_beginResult)
-    _error = 1;
+  if (!_beginResult) _error = 1;
   return _beginResult;
 }
 

--- a/src/Updater.h
+++ b/src/Updater.h
@@ -13,34 +13,47 @@
 
 class UpdateClass {
  public:
-  bool begin(size_t size = 0, int command = U_FLASH) {
-    (void)size;
-    (void)command;
-    return false;
-  }
-  bool end(bool evenIfRemaining = false) {
-    (void)evenIfRemaining;
-    return false;
-  }
+  bool begin(size_t size = 0, int command = U_FLASH);
+  bool end(bool evenIfRemaining = false);
   size_t write(uint8_t* data, size_t len) {
     (void)data;
     return 0;
   }
-  size_t writeStream(Stream& stream) {
-    (void)stream;
-    return 0;
-  }
+  size_t writeStream(Stream& stream);
   bool isRunning() { return false; }
   bool isFinished() { return false; }
   bool hasError() { return false; }
-  uint8_t getError() { return 0; }
-  void clearError() {}
+  uint8_t getError() { return _error; }
+  void clearError() { _error = 0; }
   const char* errorString() { return ""; }
   size_t size() { return 0; }
   size_t progress() { return 0; }
   size_t remaining() { return 0; }
   void abort() {}
   void printError(void*) {}
+
+  // Test configuration
+  static void setBeginResult(bool result) { _beginResult = result; }
+  static void setWriteStreamResult(size_t n) { _writeResult = n; }
+  static void setError(uint8_t e) { _error = e; }
+  static void reset() {
+    _beginResult = false;
+    _writeResult = 0;
+    _error = 0;
+    _endCallCount = 0;
+    _lastEndArg = false;
+  }
+
+  // Test observability
+  static int endCallCount() { return _endCallCount; }
+  static bool lastEndArg() { return _lastEndArg; }
+
+ private:
+  static bool _beginResult;
+  static size_t _writeResult;
+  static uint8_t _error;
+  static int _endCallCount;
+  static bool _lastEndArg;
 };
 
 extern UpdateClass Update;

--- a/test/updater_gtest.cpp
+++ b/test/updater_gtest.cpp
@@ -2,43 +2,154 @@
 
 #include "Update.h"
 
-TEST(UpdaterTest, BeginDefaultReturnsFalse) { EXPECT_FALSE(Update.begin()); }
+class UpdaterTest : public ::testing::Test {
+ protected:
+  void SetUp() override { UpdateClass::reset(); }
+};
 
-TEST(UpdaterTest, BeginWithSizeReturnsFalse) { EXPECT_FALSE(Update.begin(1024)); }
+// --- Defaults after reset ---
 
-TEST(UpdaterTest, EndReturnsFalse) { EXPECT_FALSE(Update.end()); }
+TEST_F(UpdaterTest, BeginDefaultReturnsFalse) { EXPECT_FALSE(Update.begin()); }
 
-TEST(UpdaterTest, HasErrorReturnsFalse) { EXPECT_FALSE(Update.hasError()); }
+TEST_F(UpdaterTest, BeginWithSizeReturnsFalse) { EXPECT_FALSE(Update.begin(1024)); }
 
-TEST(UpdaterTest, ErrorStringIsEmpty) { EXPECT_STREQ(Update.errorString(), ""); }
-
-TEST(UpdaterTest, IsRunningReturnsFalse) { EXPECT_FALSE(Update.isRunning()); }
-
-TEST(UpdaterTest, IsFinishedReturnsFalse) { EXPECT_FALSE(Update.isFinished()); }
-
-TEST(UpdaterTest, SizeReturnsZero) { EXPECT_EQ(Update.size(), 0u); }
-
-TEST(UpdaterTest, ProgressReturnsZero) { EXPECT_EQ(Update.progress(), 0u); }
-
-TEST(UpdaterTest, RemainingReturnsZero) { EXPECT_EQ(Update.remaining(), 0u); }
-
-TEST(UpdaterTest, AbortDoesNotCrash) { Update.abort(); }
-
-TEST(UpdaterTest, ClearErrorDoesNotCrash) { Update.clearError(); }
-
-TEST(UpdaterTest, GlobalUpdateInstanceIsAccessible) {
-  UpdateClass* ptr = &Update;
-  EXPECT_NE(ptr, nullptr);
-}
-
-TEST(UpdaterTest, UFlashAndUSpiffsDefined) {
-  EXPECT_EQ(U_FLASH, 0);
-  EXPECT_EQ(U_SPIFFS, 100);
-}
-
-TEST(UpdaterTest, BeginWithCommand) {
+TEST_F(UpdaterTest, BeginWithCommandReturnsFalse) {
   EXPECT_FALSE(Update.begin(1024, U_FLASH));
   EXPECT_FALSE(Update.begin(1024, U_SPIFFS));
 }
 
-TEST(UpdaterTest, GetErrorReturnsZero) { EXPECT_EQ(Update.getError(), static_cast<uint8_t>(0)); }
+TEST_F(UpdaterTest, EndReturnsTrueByDefault) { EXPECT_TRUE(Update.end()); }
+
+TEST_F(UpdaterTest, HasErrorReturnsFalse) { EXPECT_FALSE(Update.hasError()); }
+
+TEST_F(UpdaterTest, ErrorStringIsEmpty) { EXPECT_STREQ(Update.errorString(), ""); }
+
+TEST_F(UpdaterTest, IsRunningReturnsFalse) { EXPECT_FALSE(Update.isRunning()); }
+
+TEST_F(UpdaterTest, IsFinishedReturnsFalse) { EXPECT_FALSE(Update.isFinished()); }
+
+TEST_F(UpdaterTest, SizeReturnsZero) { EXPECT_EQ(Update.size(), 0u); }
+
+TEST_F(UpdaterTest, ProgressReturnsZero) { EXPECT_EQ(Update.progress(), 0u); }
+
+TEST_F(UpdaterTest, RemainingReturnsZero) { EXPECT_EQ(Update.remaining(), 0u); }
+
+TEST_F(UpdaterTest, AbortDoesNotCrash) { Update.abort(); }
+
+TEST_F(UpdaterTest, ClearErrorDoesNotCrash) { Update.clearError(); }
+
+TEST_F(UpdaterTest, GlobalUpdateInstanceIsAccessible) {
+  UpdateClass* ptr = &Update;
+  EXPECT_NE(ptr, nullptr);
+}
+
+TEST_F(UpdaterTest, UFlashAndUSpiffsDefined) {
+  EXPECT_EQ(U_FLASH, 0);
+  EXPECT_EQ(U_SPIFFS, 100);
+}
+
+TEST_F(UpdaterTest, GetErrorReturnsZeroAfterReset) {
+  EXPECT_EQ(Update.getError(), static_cast<uint8_t>(0));
+}
+
+// --- Test configuration helpers ---
+
+TEST_F(UpdaterTest, SetBeginResultTrue) {
+  UpdateClass::setBeginResult(true);
+  EXPECT_TRUE(Update.begin());
+}
+
+TEST_F(UpdaterTest, SetBeginResultFalse) {
+  UpdateClass::setBeginResult(false);
+  EXPECT_FALSE(Update.begin());
+}
+
+TEST_F(UpdaterTest, SetWriteStreamResult) {
+  UpdateClass::setWriteStreamResult(512);
+  // writeStream needs a Stream& — use a minimal stand-in via a null cast
+  // The stub ignores the stream object entirely
+  Stream* s = nullptr;
+  EXPECT_EQ(Update.writeStream(*s), 512u);
+}
+
+TEST_F(UpdaterTest, SetErrorConfiguresGetError) {
+  UpdateClass::setError(7);
+  EXPECT_EQ(Update.getError(), static_cast<uint8_t>(7));
+}
+
+TEST_F(UpdaterTest, ClearErrorResetsToZero) {
+  UpdateClass::setError(3);
+  Update.clearError();
+  EXPECT_EQ(Update.getError(), static_cast<uint8_t>(0));
+}
+
+// --- Observability ---
+
+TEST_F(UpdaterTest, EndCallCountStartsAtZero) { EXPECT_EQ(UpdateClass::endCallCount(), 0); }
+
+TEST_F(UpdaterTest, EndCallCountIncrementsOnEachCall) {
+  Update.end();
+  Update.end();
+  EXPECT_EQ(UpdateClass::endCallCount(), 2);
+}
+
+TEST_F(UpdaterTest, LastEndArgReflectsCommitTrue) {
+  Update.end(true);
+  EXPECT_TRUE(UpdateClass::lastEndArg());
+}
+
+TEST_F(UpdaterTest, LastEndArgReflectsCommitFalse) {
+  Update.end(false);
+  EXPECT_FALSE(UpdateClass::lastEndArg());
+}
+
+TEST_F(UpdaterTest, ResetClearsEndCallCount) {
+  Update.end();
+  UpdateClass::reset();
+  EXPECT_EQ(UpdateClass::endCallCount(), 0);
+}
+
+// --- OTA scenario tests ---
+
+TEST_F(UpdaterTest, SuccessfulOTA) {
+  UpdateClass::setBeginResult(true);
+  UpdateClass::setWriteStreamResult(1024);
+
+  ASSERT_TRUE(Update.begin(1024));
+  Stream* s = nullptr;
+  EXPECT_EQ(Update.writeStream(*s), 1024u);
+  Update.end(true);
+
+  EXPECT_EQ(UpdateClass::endCallCount(), 1);
+  EXPECT_TRUE(UpdateClass::lastEndArg());
+}
+
+TEST_F(UpdaterTest, PartialWriteAborts) {
+  UpdateClass::setBeginResult(true);
+  UpdateClass::setWriteStreamResult(512);  // only half written
+
+  ASSERT_TRUE(Update.begin(1024));
+  Stream* s = nullptr;
+  size_t written = Update.writeStream(*s);
+  bool commit = (written == 1024);
+  Update.end(commit);
+
+  EXPECT_EQ(UpdateClass::endCallCount(), 1);
+  EXPECT_FALSE(UpdateClass::lastEndArg());  // abort — partition protected
+}
+
+TEST_F(UpdaterTest, BeginFailureNeverCallsEnd) {
+  UpdateClass::setBeginResult(false);
+
+  if (Update.begin(1024)) {
+    Update.end(true);
+  }
+
+  EXPECT_EQ(UpdateClass::endCallCount(), 0);
+}
+
+TEST_F(UpdaterTest, BeginFailureSetsError) {
+  UpdateClass::setBeginResult(false);
+  Update.begin(1024);
+  EXPECT_NE(Update.getError(), static_cast<uint8_t>(0));
+}

--- a/test/updater_gtest.cpp
+++ b/test/updater_gtest.cpp
@@ -141,9 +141,7 @@ TEST_F(UpdaterTest, PartialWriteAborts) {
 TEST_F(UpdaterTest, BeginFailureNeverCallsEnd) {
   UpdateClass::setBeginResult(false);
 
-  if (Update.begin(1024)) {
-    Update.end(true);
-  }
+  if (Update.begin(1024)) { Update.end(true); }
 
   EXPECT_EQ(UpdateClass::endCallCount(), 0);
 }


### PR DESCRIPTION
## Summary

- Makes `UpdateClass` configurable for testing OTA update code paths, following the same pattern as `WiFiClient::setCanConnect`
- Adds static configuration helpers (`setBeginResult`, `setWriteStreamResult`, `setError`, `reset`) and observability methods (`endCallCount`, `lastEndArg`)
- Adds scenario-based tests covering successful OTA, partial write abort, begin failure, and error propagation

Closes #162
