### PR TITLE
feat: add xTaskNotifyWait, fix value=0 notification wakeup, add semphr/task path shims

### DIFF
--- a/src/freertos/semphr.h
+++ b/src/freertos/semphr.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Shim matching the ESP32 include path <freertos/semphr.h>
+#include "semaphore/semaphore.h"

--- a/src/freertos/task.h
+++ b/src/freertos/task.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Shim matching the ESP32 include path <freertos/task.h>
+#include "task/task.h"

--- a/src/freertos/task/task.cpp
+++ b/src/freertos/task/task.cpp
@@ -147,20 +147,21 @@ uint32_t ulTaskNotifyTake(BaseType_t xClearCountOnExit, TickType_t xTicksToWait)
   TaskImpl* impl = tls_current_task;
   if (impl == nullptr) return 0;
   std::unique_lock<std::mutex> lk(impl->mtx);
-  auto pred = [impl]() { return impl->notificationValue > 0 || impl->cancel.load(); };
+  auto pred = [impl]() { return impl->notificationPending || impl->cancel.load(); };
   if (xTicksToWait == portMAX_DELAY) {
     impl->cv.wait(lk, pred);
   } else {
     impl->cv.wait_for(lk, std::chrono::milliseconds(xTicksToWait), pred);
   }
-  if (impl->notificationValue == 0) return 0;
+  if (!impl->notificationPending) return 0;
+  impl->notificationPending = false;
   uint32_t value = impl->notificationValue;
   if (xClearCountOnExit == pdTRUE) {
     impl->notificationValue = 0;
   } else {
     impl->notificationValue--;
   }
-  impl->notificationPending = (impl->notificationValue > 0);
+  impl->notificationPending = (impl->notificationValue > 0);  // still pending if count remains
   return value;
 }
 

--- a/src/freertos/task/task.h
+++ b/src/freertos/task/task.h
@@ -56,6 +56,16 @@ TickType_t xTaskGetTickCount(void);
 BaseType_t xTaskNotify(TaskHandle_t xTaskToNotify, uint32_t ulValue, eNotifyAction eAction);
 uint32_t ulTaskNotifyTake(BaseType_t xClearCountOnExit, TickType_t xTicksToWait);
 
+static inline BaseType_t xTaskNotifyWait(
+    uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t* pulNotificationValue,
+    TickType_t xTicksToWait) {
+  (void)ulBitsToClearOnEntry;
+  (void)ulBitsToClearOnExit;
+  uint32_t v = ulTaskNotifyTake(pdTRUE, xTicksToWait);
+  if (pulNotificationValue != NULL) *pulNotificationValue = v;
+  return v > 0 ? pdTRUE : pdFALSE;
+}
+
 // Optional helpers used by hooks/tests
 size_t xPortGetFreeHeapSize(void);
 

--- a/test/task_gtest.cpp
+++ b/test/task_gtest.cpp
@@ -5,6 +5,8 @@
 #include <thread>
 
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
 
 static void simple_task(void*) {
   vTaskDelay(pdMS_TO_TICKS(30));
@@ -188,6 +190,64 @@ TEST(TaskNotifyTest, SetValueWithoutOverwriteDoesNotReplaceIfPending) {
 
 TEST(TaskNotifyTest, NullHandleReturnsFail) {
   EXPECT_EQ(xTaskNotify(nullptr, 0u, eSetValueWithOverwrite), pdFALSE);
+}
+
+TEST(TaskNotifyTest, ZeroValueNotificationWakesTask) {
+  struct ZeroArgs {
+    std::atomic<bool> woke{false};
+    std::atomic<bool> done{false};
+  };
+  ZeroArgs s;
+  TaskHandle_t th = nullptr;
+  ASSERT_EQ(
+      xTaskCreate(
+          [](void* arg) {
+            auto* s = static_cast<ZeroArgs*>(arg);
+            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(500));
+            s->woke.store(true);
+            s->done.store(true);
+            vTaskDelete(nullptr);
+          },
+          "zero", 2048, &s, tskIDLE_PRIORITY + 1, &th),
+      pdPASS);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  EXPECT_EQ(xTaskNotify(th, 0u, eSetValueWithOverwrite), pdPASS);
+
+  for (int i = 0; i < 100 && !s.done.load(); ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+  EXPECT_TRUE(s.woke.load());
+}
+
+TEST(TaskNotifyTest, xTaskNotifyWaitReceivesValue) {
+  struct WaitArgs {
+    std::atomic<uint32_t> received{0};
+    std::atomic<bool> done{false};
+  };
+  WaitArgs s;
+  TaskHandle_t th = nullptr;
+  ASSERT_EQ(
+      xTaskCreate(
+          [](void* arg) {
+            auto* s = static_cast<WaitArgs*>(arg);
+            uint32_t val = 0;
+            xTaskNotifyWait(0, 0, &val, pdMS_TO_TICKS(500));
+            s->received.store(val);
+            s->done.store(true);
+            vTaskDelete(nullptr);
+          },
+          "nwait", 2048, &s, tskIDLE_PRIORITY + 1, &th),
+      pdPASS);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  EXPECT_EQ(xTaskNotify(th, 77u, eSetValueWithOverwrite), pdPASS);
+
+  for (int i = 0; i < 100 && !s.done.load(); ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+  EXPECT_TRUE(s.done.load());
+  EXPECT_EQ(s.received.load(), 77u);
 }
 
 // --- vTaskSuspend / vTaskResume tests ---


### PR DESCRIPTION
## Summary

Three FreeRTOS gaps discovered via native testing (issue #170):

- **Fix `ulTaskNotifyTake` predicate** — predicate was `notificationValue > 0`, which caused tasks waiting on a value=0 notification (e.g. `xTaskNotify(h, 0, eSetValueWithOverwrite)`) to sleep the full timeout instead of waking immediately. Predicate now uses `notificationPending`, which is set on every `xTaskNotify` call regardless of value
- **Add `xTaskNotifyWait`** — inline shim in `task.h` delegating to `ulTaskNotifyTake`; C-compatible so it works from `freertos_hooks.c`
- **Add `freertos/semphr.h` and `freertos/task.h` path shims** — mirrors the existing `freertos/timers.h` shim; ESP-IDF code uses these canonical include paths while ArduinoMock has the files at `semaphore/semaphore.h` and `task/task.h`

Closes #170

## Test plan

- [ ] `task_gtest` suite passes (`make test`)
- [ ] `ZeroValueNotificationWakesTask` — task notified with value=0 wakes before timeout
- [ ] `xTaskNotifyWaitReceivesValue` — value delivered correctly via `xTaskNotifyWait`
- [ ] Existing notification tests unchanged (no regression)
- [ ] `freertos/semphr.h` and `freertos/task.h` includes compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)